### PR TITLE
Redesign how strokes are handled internally

### DIFF
--- a/generator/config.py
+++ b/generator/config.py
@@ -82,11 +82,10 @@ STRESS_MARKERS = ["ˈ", "ˌ"]
 #
 # Each vowel in VOWELS must have an entry here.
 #
-# If there are multiple ways to write the sound, the value should be a list of
-# strings with each string being a way to write it.
-#
-# If the sound should be stenoed with the star key, add a "*" character
-# anywhere in the string.
+# The value of each entry should be a list of ways to translate the phoneme to
+# steno; each way to translate it should itself be a list specifying the keys to
+# press and those keys should be in steno order. If the sound should be stenoed
+# with the star key, add Key.STAR anywhere in the inner list.
 VOWEL_TO_STENO = {
     ############ American English Vowels ############
     "ɪ": [[Key.E, Key.U]],
@@ -123,11 +122,10 @@ VOWEL_TO_STENO = {
 # Each consonant in CONSONANTS must have an entry here; if it's not a valid
 # left-side consonant sound its value should be NO_STENO_MAPPING.
 #
-# If there are multiple ways to write the sound with left-side consonants, the
-# value should be a list of strings with each string being a way to write it.
-#
-# If the sound should be stenoed with the star key, add a "*" character
-# anywhere in the string.
+# The value of each entry should be a list of ways to translate the phoneme to
+# steno; each way to translate it should itself be a list specifying the keys to
+# press and those keys should be in steno order. If the sound should be stenoed
+# with the star key, add Key.STAR anywhere in the inner list.
 LEFT_CONSONANT_TO_STENO = {
     "b": [[Key.LP, Key.LW]],
     "d": [[Key.LT, Key.LK]],
@@ -165,11 +163,10 @@ LEFT_CONSONANT_TO_STENO = {
 # Each consonant in CONSONANTS must have an entry here; if it's not a valid
 # right-side consonant sound its value should be NO_STENO_MAPPING.
 #
-# If there are multiple ways to write the sound with right-side consonants, the
-# value should be a list of strings with each string being a way to write it.
-#
-# If the sound should be stenoed with the star key, add a "*" character
-# anywhere in the string.
+# The value of each entry should be a list of ways to translate the phoneme to
+# steno; each way to translate it should itself be a list specifying the keys to
+# press and those keys should be in steno order. If the sound should be stenoed
+# with the star key, add Key.STAR anywhere in the inner list.
 RIGHT_CONSONANT_TO_STENO = {
     "b": [[Key.RB]],
     "d": [[Key.RD]],
@@ -279,26 +276,21 @@ def can_prepend_to_onset(phoneme, onset):
     return False
 
 
-def postprocess_steno_sequence(steno_sequence, syllables_ipa):
+def postprocess_steno_sequence(stroke_sequence, syllables_ipa):
     """Make custom modifications to a generated stroke sequence.
 
     Args:
-        steno_sequence: a string specifying the generated steno strokes. Each
-            stroke is separated by a forward slash.
+        stroke_sequence: A StrokeSequence.
         syllables_ipa: A list of Syllables, giving the pronunciation for the
             translated word via IPA. See syllable.py for more info on a
             Syllable.
 
     Returns:
-        A string that is the stroke sequence after applying any modifications.
-        This should be the input `steno_sequence` if no modifications are
-        desired for this sequence.
+        The updated StrokeSequence to use. This should be the input
+        `stroke_sequence` if no modifications are desired for this sequence.
     """
 
-    # syllables_steno = steno_sequence.split("/")
-    # new_syllables_steno = syllables_steno.copy()
-
-    new_strokes = steno_sequence.get_strokes().copy()
+    new_strokes = stroke_sequence.get_strokes().copy()
 
     # If a stroke after the first has 'U', 'EU', or 'E' as its vowel and it has
     # following consonants, replace the vowel cluster with '-' (or '*' if the
@@ -364,13 +356,12 @@ def postprocess_generated_dictionary(word_and_translations):
     Args:
         word_and_definitions: A list of tuples where the first item in each
             tuple is the word to translate into steno and the second item in
-            the tuple is a list of strings, with each string being a way to
-            write the word in steno.
+            the tuple is a StrokeSequences, with each StrokeSequence being a way
+            to write the word in steno.
 
     Returns:
-        A string that is the stroke sequence after applying any modifications.
-        This should be the input `steno_sequence` if no modifications are
-        desired for this sequence.
+        An updated version of the input after applying any modifications to the
+        each StrokeSequence.
     """
 
     # If a desired definition is already taken, append a 'W-B' stroke until

--- a/generator/config.py
+++ b/generator/config.py
@@ -1,7 +1,9 @@
 """Configuration for the steno dictionary generator."""
 
 import logging
-import re
+
+import steno
+from steno import Key
 
 
 STENO_ORDER = "STKPWHRAOEUFRPBLGTSDZ"  # Excludes the '*'.
@@ -87,32 +89,32 @@ STRESS_MARKERS = ["ˈ", "ˌ"]
 # anywhere in the string.
 VOWEL_TO_STENO = {
     ############ American English Vowels ############
-    "ɪ": "EU",
-    "ɛ": "E",
-    "æ": "A",
-    "ə": "U",
-    "ʊ": "AO",
-    "i": "AOE",
-    "ɔ": "AU",
-    "u": "AOU",  # Note: this is the same as for 'ju'.
-    "ɝ": "UR",
-    "ɑ": "O",
-    "aɪ": "AOEU",
-    "eɪ": "AEU",
-    "ɔɪ": "OEU",
-    "aʊ": "OU",
-    "oʊ": "OE",
-    "ɪɹ": "AOER",
-    "ɛɹ": "AEUR",
-    "ɔɹ": "OR",
-    "ʊɹ": "AOUR",
-    "ɑɹ": "AR",
+    "ɪ": [[Key.E, Key.U]],
+    "ɛ": [[Key.E]],
+    "æ": [[Key.A]],
+    "ə": [[Key.U]],
+    "ʊ": [[Key.A, Key.O]],
+    "i": [[Key.A, Key.O, Key.E]],
+    "ɔ": [[Key.A, Key.U]],
+    "u": [[Key.A, Key.O, Key.U]],  # Note: this is the same as for 'ju'.
+    "ɝ": [[Key.U, Key.RR]],
+    "ɑ": [[Key.O]],
+    "aɪ": [[Key.A, Key.O, Key.E, Key.U]],
+    "eɪ": [[Key.A, Key.E, Key.U]],
+    "ɔɪ": [[Key.O, Key.E, Key.U]],
+    "aʊ": [[Key.O, Key.U]],
+    "oʊ": [[Key.O, Key.E]],
+    "ɪɹ": [[Key.A, Key.O, Key.E, Key.RR]],
+    "ɛɹ": [[Key.A, Key.E, Key.U, Key.RR]],
+    "ɔɹ": [[Key.O, Key.RR]],
+    "ʊɹ": [[Key.A, Key.O, Key.U, Key.RR]],
+    "ɑɹ": [[Key.A, Key.RR]],
     ############ Extra Vowel Clusters ############
-    "ju": "AOU",  # Note: this is the same as for just 'u'.
-    "jə": "AOU",
-    "ɝtʃ": "UFRPB",
-    "ɑɹtʃ": "AFRPB",
-    "ɔɹtʃ": "OFRPB",
+    "ju": [[Key.A, Key.O, Key.U]],  # Note: this is the same as for just 'u'.
+    "jə": [[Key.A, Key.O, Key.U]],
+    "ɝtʃ": [[Key.U, Key.RF, Key.RR, Key.RP, Key.RB]],
+    "ɑɹtʃ": [[Key.A, Key.RF, Key.RR, Key.RP, Key.RB]],
+    "ɔɹtʃ": [[Key.O, Key.RF, Key.RR, Key.RP, Key.RB]],
 }
 
 # Specify how each consonant in CONSONANTS should be translated to steno using
@@ -127,31 +129,31 @@ VOWEL_TO_STENO = {
 # If the sound should be stenoed with the star key, add a "*" character
 # anywhere in the string.
 LEFT_CONSONANT_TO_STENO = {
-    "b": "PW",
-    "d": "TK",
-    "f": "TP",
-    "h": "H",
-    "j": "KWR",
-    "k": "K",
-    "m": "PH",
-    "n": "TPH",
-    "p": "P",
-    "s": "S",
-    "t": "T",
-    "v": "SR",
-    "w": "W",
-    "z": "SWR",
-    "ð": "TH",
+    "b": [[Key.LP, Key.LW]],
+    "d": [[Key.LT, Key.LK]],
+    "f": [[Key.LT, Key.LP]],
+    "h": [[Key.LH]],
+    "j": [[Key.LK, Key.LW, Key.LR]],
+    "k": [[Key.LK]],
+    "m": [[Key.LP, Key.LH]],
+    "n": [[Key.LT, Key.LP, Key.LH]],
+    "p": [[Key.LP]],
+    "s": [[Key.LS]],
+    "t": [[Key.LT]],
+    "v": [[Key.LS, Key.LR]],
+    "w": [[Key.LW]],
+    "z": [[Key.LS, Key.LW, Key.LR]],
+    "ð": [[Key.LT, Key.LH]],
     "ŋ": NO_STENO_MAPPING,
-    "ɡ": "TKPW",
-    "ɫ": "HR",
-    "ɹ": "R",
-    "ʃ": "SH",
-    "ʒ": "SKH",
-    "θ": "TH",
-    "tʃ": "KH",
-    "dʒ": "SKWR",
-    "st": "ST",
+    "ɡ": [[Key.LT, Key.LK, Key.LP, Key.LW]],
+    "ɫ": [[Key.LH, Key.LR]],
+    "ɹ": [[Key.LR]],
+    "ʃ": [[Key.LS, Key.LH]],
+    "ʒ": [[Key.LS, Key.LK, Key.LH]],
+    "θ": [[Key.LT, Key.LH]],
+    "tʃ": [[Key.LK, Key.LH]],
+    "dʒ": [[Key.LS, Key.LK, Key.LW, Key.LR]],
+    "st": [[Key.LS, Key.LT]],
     "ŋk": NO_STENO_MAPPING,
     "mp": NO_STENO_MAPPING,
     "ntʃ": NO_STENO_MAPPING,
@@ -169,34 +171,34 @@ LEFT_CONSONANT_TO_STENO = {
 # If the sound should be stenoed with the star key, add a "*" character
 # anywhere in the string.
 RIGHT_CONSONANT_TO_STENO = {
-    "b": "B",
-    "d": "D",
-    "f": "F",
+    "b": [[Key.RB]],
+    "d": [[Key.RD]],
+    "f": [[Key.RF]],
     "h": NO_STENO_MAPPING,
     "j": NO_STENO_MAPPING,
-    "k": "BG",
-    "m": "PL",
-    "n": "PB",
-    "p": "P",
-    "s": ["S", "F"],
-    "t": "T",
-    "v": "FB",
+    "k": [[Key.RB, Key.RG]],
+    "m": [[Key.RP, Key.RL]],
+    "n": [[Key.RP, Key.RB]],
+    "p": [[Key.RP]],
+    "s": [[Key.RS], [Key.RF]],
+    "t": [[Key.RT]],
+    "v": [[Key.RF, Key.RB]],
     "w": NO_STENO_MAPPING,
-    "z": "Z",
-    "ð": "*T",
-    "ŋ": "PBG",
-    "ɡ": "G",
-    "ɫ": "L",
-    "ɹ": "R",
-    "ʃ": "RB",
+    "z": [[Key.RZ]],
+    "ð": [[Key.STAR, Key.RT]],
+    "ŋ": [[Key.RP, Key.RB, Key.RG]],
+    "ɡ": [[Key.RG]],
+    "ɫ": [[Key.RL]],
+    "ɹ": [[Key.RR]],
+    "ʃ": [[Key.RR, Key.RB]],
     "ʒ": NO_STENO_MAPPING,
-    "θ": "*T",
-    "tʃ": "FP",
-    "dʒ": "PBLG",
-    "st": ["FT", "*S"],
-    "ŋk": "PBG",  # Note: this colides with 'ŋ'.
-    "mp": "*PL",
-    "ntʃ": "FRPB",
+    "θ": [[Key.STAR, Key.RT]],
+    "tʃ": [[Key.RF, Key.RP]],
+    "dʒ": [[Key.RP, Key.RB, Key.RL, Key.RG]],
+    "st": [[Key.RF, Key.RT], [Key.STAR, Key.RS]],
+    "ŋk": [[Key.RP, Key.RB, Key.RG]],  # Note: this colides with 'ŋ'.
+    "mp": [[Key.STAR, Key.RP, Key.RL]],
+    "ntʃ": [[Key.RF, Key.RR, Key.RP, Key.RB]],
 }
 
 
@@ -293,63 +295,65 @@ def postprocess_steno_sequence(steno_sequence, syllables_ipa):
         desired for this sequence.
     """
 
-    syllables_steno = steno_sequence.split("/")
-    new_syllables_steno = syllables_steno.copy()
+    # syllables_steno = steno_sequence.split("/")
+    # new_syllables_steno = syllables_steno.copy()
+
+    new_strokes = steno_sequence.get_strokes().copy()
 
     # If a stroke after the first has 'U', 'EU', or 'E' as its vowel and it has
     # following consonants, replace the vowel cluster with '-' (or '*' if the
     # stroke is starred).
-    for i in range(1, len(syllables_steno)):
-        pattern = "([STKPWHR]*)([AO]*)([*]?)([EU]*)([FRPBLGTSDZ]*)"
-        match = re.match(pattern, syllables_steno[i])
+    for stroke in new_strokes[1:]:
+        active_vowels = stroke.get_vowels()
+        last_key = stroke.get_last_key()
 
-        if match:
-            (left, a_and_o, star, e_and_u, right) = match.groups()
-
-        if a_and_o == "" and len(e_and_u) != 0 and right != "":
-            # Remove the vowels.
-            middle = "*" if star == "*" else "-"
-            new_syllables_steno[i] = left + middle + right
+        if active_vowels in [[Key.E], [Key.E, Key.U], [Key.U]] and (
+            last_key is not None and last_key.index > Key.U.index
+        ):
+            stroke.clear_all_vowels()
 
     # If the final sound in a syllable is an 's', it should be with the 'S' key
     # not the 'F' key, even though making 's' with 'F' is allowed if there's
     # another sound later in the syllable.
-    for steno, ipa in zip(new_syllables_steno, syllables_ipa):
-        if steno[-1] == "F" and len(ipa.coda) > 0 and ipa.coda[-1] == "s":
+    for stroke, ipa in zip(new_strokes, syllables_ipa):
+        if stroke.get_last_key() == Key.RF and len(ipa.coda) > 0 and ipa.coda[-1] == "s":
             # This is invalid.
             return None
 
     # If the final stroke is 'SH-PB', fold it into the previous stroke as '-GS'.
-    if len(new_syllables_steno) > 1 and new_syllables_steno[-1] == "SH-PB":
-        prev = new_syllables_steno[-2]
-        if prev[-1] not in ["T", "D", "Z"] and "GS" not in prev:
-            # We can fold it in; just make sure not to repeat a key.
-            if prev[-1] == "G":
-                prev += "S"
-            elif prev[-1] == "S":
-                # We already know there's not a right-side 'T' or 'G', so we
-                # can put a 'G' immediately before the 'S'.
-                prev = prev[:-1] + "GS"
-            else:
-                prev += "GS"
+    shun_stroke = steno.Stroke([Key.LS, Key.LH, Key.RP, Key.RB])
+    if len(new_strokes) > 1 and new_strokes[-1] == shun_stroke:
+        prev_stroke = new_strokes[-2]
+        prev_stroke_keys = prev_stroke.get_keys()
+
+        if (
+            len(prev_stroke_keys) > 0
+            and prev_stroke_keys[-1] not in [Key.RT, Key.RD, Key.RZ]
+            and (Key.RG not in prev_stroke_keys or Key.RS not in prev_stroke_keys)
+        ):
+            prev_stroke.add_keys_maintain_steno_order([Key.RG, Key.RS])
 
             # Now actually replace the strokes.
-            new_syllables_steno = new_syllables_steno[:-1]
-            new_syllables_steno[-1] = prev
+            new_strokes = new_strokes[:-1]
 
     # If a stroke other than the last one in a multistroke entry conssists
     # entirely of 'TK' plus either 'AOE', 'E', 'EU', or 'U', then remvoe the
     # vowels. This is becuase such words (such as 'develop') can often be
     # pronunced in several of these ways.
-    for i, stroke in enumerate(new_syllables_steno[:-1]):
-        if len(stroke) > 2 and stroke[:2] == "TK" and stroke[2:] in ["AOE", "E", "EU", "U"]:
-            new_syllables_steno[i] = "TK-"
+    for stroke in new_strokes[:-1]:
+        stroke_str = str(stroke)
+        if (
+            len(stroke_str) > 2
+            and stroke_str[:2] == "TK"
+            and stroke_str[2:] in ["AOE", "E", "EU", "U"]
+        ):
+            stroke.clear_all_vowels()
 
-    return "/".join(new_syllables_steno)
+    return steno.StrokeSequence(new_strokes)
 
 
 # Perform custom postprocessing after the entire dictionary's been generated.
-def postprocess_generated_dictionary(word_and_definitions):
+def postprocess_generated_dictionary(word_and_translations):
     """Make custom modifications to the generated steno dictionary.
 
     This can be used to resolve homophone conflicts for example, by looping
@@ -371,14 +375,14 @@ def postprocess_generated_dictionary(word_and_definitions):
 
     # If a desired definition is already taken, append a 'W-B' stroke until
     # it's unique.
-    used_definitions = set()
+    used_translation_strs = set()
+    disambiguator_stroke = steno.Stroke([Key.LW, Key.RB])
 
-    for _, (_, definitions) in enumerate(word_and_definitions):
-        for k, strokes in enumerate(definitions):
-            while strokes in used_definitions:
-                strokes += "/W-B"
+    for _, translations in word_and_translations:
+        for translation in translations:
+            while str(translation) in used_translation_strs:
+                translation.append_stroke(disambiguator_stroke)
 
-            definitions[k] = strokes
-            used_definitions.add(strokes)
+            used_translation_strs.add(str(translation))
 
-    return word_and_definitions
+    return word_and_translations

--- a/generator/core.py
+++ b/generator/core.py
@@ -64,8 +64,8 @@ def generate_dictionary(ipa_file, word_list_file):
             generated.
     Returns:
         A list of tuples where theh first item in each tuple is a word from
-        `word_list_file` and the second item in the tuple is a list of strings,
-        with each string being a way to write the word in steno.
+        `word_list_file` and the second item in the tuple is a list of
+        StrokeSequences, giving the valid ways to steno that word.
     """
 
     # Make a list of tuples. The first part of the tuple is the desired word,
@@ -103,7 +103,7 @@ def generate_dictionary(ipa_file, word_list_file):
                     log.debug("Generated %s for `%s`", translations, word)
                     translations_for_word += translations
 
-            # Remove duplicate steno sequences.
+            # Remove duplicate translations.
             translations_for_word = sorted(list(set(translations_for_word)))
 
             if len(translations_for_word) == 0:
@@ -124,7 +124,7 @@ def write_dictionary_to_file(words_and_translations, output_file):
     """Write steno strokes for words to a file in JSON format.
 
     Args:
-        words_and_translations: the returned value from generate_dictionary()
+        words_and_translations: the returned value from generate_dictionary().
         output_file: the name of the output file. This should be a JSON file.
     """
 

--- a/generator/steno.py
+++ b/generator/steno.py
@@ -1,0 +1,283 @@
+"""Manage steno keys, strokes, and sequences of strokes."""
+
+from enum import Enum
+
+
+class MissingDashInStrokeError(Exception):
+    """Error for when a steno stroke string is missing a middle.
+
+    This should be thrown when a string representing a stroke doesn't have any
+    vowels and also doesn't have an asterisk.
+    """
+
+
+class OutOfStenoOrderError(Exception):
+    """Error for when the keys of a steno stroke are out of order."""
+
+
+class Key(Enum):
+    """Enum for the keys on a steno keyboard."""
+
+    NUM = (0, "#")
+    LS = (1, "S")
+    LT = (2, "T")
+    LK = (3, "K")
+    LP = (4, "P")
+    LW = (5, "W")
+    LH = (6, "H")
+    LR = (7, "R")
+    A = (8, "A")
+    O = (9, "O")
+    STAR = (10, "*")
+    E = (11, "E")
+    U = (12, "U")
+    RF = (13, "F")
+    RR = (14, "R")
+    RP = (15, "P")
+    RB = (16, "B")
+    RL = (17, "L")
+    RG = (18, "G")
+    RT = (19, "T")
+    RS = (20, "S")
+    RD = (21, "D")
+    RZ = (22, "Z")
+
+    def __init__(self, index, letter):
+        self.index = index
+        self.letter = letter
+
+
+class Stroke:
+    """A single steno stroke."""
+
+    def __init__(self, keys=None):
+        self._active_keys_bitmap = [False] * len(Key)
+        self._last_active_pos = -1
+
+        if keys is not None:
+            self.add_keys_maintain_steno_order(keys)
+
+    def __eq__(self, other):
+        if self._last_active_pos != other._last_active_pos:
+            return False
+
+        return self._active_keys_bitmap == other._active_keys_bitmap
+
+    def __lt__(self, other):
+        for i, (active_self, active_other) in enumerate(
+            zip(self._active_keys_bitmap, other._active_keys_bitmap)
+        ):
+            if active_self and not active_other:
+                return other._last_active_pos > i
+
+            if active_other and not active_self:
+                return self._last_active_pos < i
+
+        return False
+
+    def __hash__(self):
+        return hash(tuple(self._active_keys_bitmap))
+
+    def __str__(self):
+        result = ""
+        has_vowel_or_star = False
+
+        for key in Key:
+            if self._active_keys_bitmap[key.index]:
+                result += key.letter
+
+                if key.letter in ["A", "O", "*", "E", "U"]:
+                    has_vowel_or_star = True
+
+            if key is Key.U and not has_vowel_or_star:
+                result += "-"
+
+        return result
+
+    @staticmethod
+    def from_string(stroke_str):
+        """Create a stroke from its string representation.
+
+        If the input string doesn't contain any vowels or an asterisk, it must
+        include a "-" to indicate separation between the left and right
+        consonants, even if only consonants on one side are present in the
+        stroke.
+
+        Args:
+            stroke_str: A string representing a single steno stroke. For
+                example, "TP*EURS", "S-P".
+
+        Raises:
+            MissingDashInStrokeError: If the input string doesn't have any
+                vowels and it doesn't have an asterisk and it doens't have a
+                dash to denote the split between left and right consonants.
+            OutOfStenoOrderError: If the keys in the input string are out of
+                steno order.
+
+        Returns:
+            The stroke corresponding to the input string.
+        """
+
+        keys = []
+        past_middle = False
+
+        for key_str in stroke_str:
+            if key_str == "-":
+                past_middle = True
+                continue
+
+            if key_str == "#":
+                keys.append(Key.NUM)
+                continue
+
+            for key in [Key.A, Key.O, Key.STAR, Key.E, Key.U]:
+                if key_str == key.letter:
+                    past_middle = True
+                    keys.append(key)
+                    break
+
+            consonants = [Key.LS, Key.LT, Key.LK, Key.LP, Key.LW, Key.LH, Key.LR]
+            if past_middle:
+                consonants = [
+                    Key.RF,
+                    Key.RR,
+                    Key.RP,
+                    Key.RB,
+                    Key.RL,
+                    Key.RG,
+                    Key.RT,
+                    Key.RS,
+                    Key.RD,
+                    Key.RZ,
+                ]
+
+            for key in consonants:
+                if key_str == key.letter:
+                    keys.append(key)
+                    break
+
+        if not past_middle:
+            raise MissingDashInStrokeError()
+
+        return Stroke(keys=keys)
+
+    def add_keys_maintain_steno_order(self, keys):
+        """Add keys to this stroke while ensuring steno order is maintained.
+
+        Args:
+            keys: list(Key)
+
+        Raises:
+            OutOfStenoOrderError: If appending the keys to the stroke would put
+            the stroke out of steno order.
+        """
+
+        for key in keys:
+            if key not in [Key.NUM, Key.STAR]:
+                if key.index < self._last_active_pos:
+                    raise OutOfStenoOrderError()
+
+                self._last_active_pos = key.index
+
+            self._active_keys_bitmap[key.index] = True
+
+    def clear_keys(self, keys):
+        """Removes the specified keys from this stroke.
+
+        This works even if some of the keys are not already in the stroke.
+
+        Args:
+            keys: list(Key)
+        """
+
+        for key in keys:
+            self._active_keys_bitmap[key.index] = False
+
+        # Update `self._last_active_pos`.
+        self._last_active_pos = -1
+        for key in reversed(Key):
+            if self._active_keys_bitmap[key.index] and key not in [Key.NUM, Key.STAR]:
+                self._last_active_pos = key.index
+                break
+
+    def clear_all_vowels(self):
+        """Remove all vowels from this stroke."""
+
+        self.clear_keys([Key.A, Key.O, Key.E, Key.U])
+
+    def get_vowels(self):
+        """Return the list of vowel keys in this stroke."""
+
+        active_vowels = []
+
+        for key in [Key.A, Key.O, Key.E, Key.U]:
+            if self._active_keys_bitmap[key.index]:
+                active_vowels.append(key)
+
+        return active_vowels
+
+    def get_last_key(self):
+        """Return the last key in this stroke, or None if there are no keys."""
+
+        if self._last_active_pos == -1:
+            return None
+
+        return list(Key)[self._last_active_pos]
+
+    def get_keys(self):
+        """Return the list of keys present in this stroke."""
+
+        keys = []
+
+        for key in Key:
+            if self._active_keys_bitmap[key.index]:
+                keys.append(key)
+
+        return keys
+
+
+class StrokeSequence:
+    """A series of Strokes, meant to represent one translation."""
+
+    def __init__(self, strokes=None):
+        self._strokes = strokes if strokes is not None else []
+
+    def __eq__(self, other):
+        return self._strokes == other._strokes
+
+    def __hash__(self):
+        return hash(tuple(self._strokes))
+
+    def __lt__(self, other):
+        if len(self._strokes) < len(other._strokes):
+            return True
+
+        if len(self._strokes) > len(other._strokes):
+            return False
+
+        for stroke1, stroke2 in zip(self._strokes, other._strokes):
+            if stroke1 < stroke2:
+                return True
+
+            if stroke1 > stroke2:
+                return False
+
+        return False
+
+    def __str__(self):
+        return "/".join([str(stroke) for stroke in self._strokes])
+
+    def get_strokes(self):
+        """Return the list of strokes comprising this sequence."""
+
+        return self._strokes
+
+    def append_stroke(self, stroke):
+        """Append a stroke to this sequence."""
+
+        self._strokes.append(stroke)
+
+    def set_strokes(self, strokes):
+        """Overwrite this sequence with the provided list of strokes."""
+
+        self._strokes = strokes

--- a/generator/stroke_builder.py
+++ b/generator/stroke_builder.py
@@ -58,9 +58,9 @@ def syllables_to_steno(syllables):
         syllables: A list of Syllables (see syllable.py)
 
     Returns:
-        A list of strings. Each string is way to write `syllables` in steno
-        given the rules for syllable splitting, postprocessing, and phoneme to
-        steno key conversion in config.py.
+        A list of StrokeSequences. Each stroke sequence is a way to steno the
+        word for the input syllables given the rules for syllable splitting,
+        postprocessing, and phoneme to steno key conversion.
     """
 
     log = logging.getLogger("dictionary_generator")

--- a/generator/stroke_builder.py
+++ b/generator/stroke_builder.py
@@ -1,138 +1,10 @@
 """Convert IPA syllables into steno strokes."""
 
+import copy
 import logging
 
 import config
-
-
-# Each of the parameters is a list of keys to stroke. Each element of each
-# paramter is the keys corresponding to one phoneme in the syllable.
-def build_stroke_from_components(components):
-    """Create a steno stroke from a list of components of the stroke.
-
-    Example:
-        components = ["PB", "OE", "*T"]
-        returns "PBO*ET"
-
-    If any component has a "*" in any position, then the returned stroke will
-    have a "*" in the correct position, otherwise it will not have a star.
-
-    Note: This function requires that one of the components has at least one
-    vowels character (A, O, E, or U).
-
-    Args:
-        Components: A list of steno stroke components. Each element of the list
-            is a string specifying keys to add to the stroke, and any element
-            may contain a "*" anywhere to indicate that a "*" should be added
-            to the correct position in the stroke.
-
-    Returns:
-        A string that is the concatenation of `components` but with the "*" (if
-        any) placed in the correct place.
-        If concatenating `components` would give a stroke that is out of steno
-        order, then None is returned instead.
-    """
-
-    log = logging.getLogger("dictionary_generator")
-    info = build_stroke_helper(components)
-
-    if info is None:
-        return None
-
-    (stroke, has_star) = info
-
-    # Make sure there's a vowel key. If there aren't any, then we need to place
-    # a '-' where the vowels would be. However, the logic gets a bit tricky
-    # because some consonants are on both the left and right sides. So to make
-    # it easier and becuase all English syllables have vowels, I'm going to
-    # require that each stroke as a vowel key.
-    has_vowel = False
-    for vowel in ["A", "O", "E", "U"]:
-        if vowel in stroke:
-            has_vowel = True
-
-    if not has_vowel:
-        log.error("No vowel key in the stroke")
-        return None
-
-    if has_star:
-        # Place the star. It goes between 'O' and 'E' in steno order. This is
-        # a bit easier since we're requiring a vowel key in each stroke.
-        pos = stroke.find("O") + 1
-
-        if pos == 0:
-            pos = stroke.find("A") + 1
-
-        if pos == 0:
-            pos = stroke.find("E")
-
-        if pos == -1:
-            pos = stroke.find("U")
-
-        if pos == -1:
-            log.error("All generated strokes must have a vowel key")
-            return None
-
-        # Add the star.
-        stroke = stroke[:pos] + "*" + stroke[pos:]
-
-    return stroke
-
-
-def build_stroke_helper(components):
-    """Create a steno stroke from a list of components of the stroke.
-
-    Example:
-        components = ["PB", "OE", "*T"]
-        returns ("PBOET", True)
-
-    If any component has a "*" in any position, then the returned stroke will
-    have a "*" in the correct position, otherwise it will not have a star.
-
-    Note: This function requires that one of the components has at least one
-    vowels character (A, O, E, or U).
-
-    Args:
-        Components: A list of steno stroke components. Each element of the list
-            is a string specifying keys to add to the stroke, and any element
-            may contain a "*" anywhere to indicate that a "*" should be added
-            to the correct position in the stroke.
-
-    Returns:
-        A tuple where the first element is the concatenation of `components`
-        but with the "*" (if any) removed, and the second element is True if
-        some componenet had a "*" anywhere.
-        If concatenating `components` would give a stroke that is out of steno
-        order, then None is returned instead.
-    """
-    stroke = ""
-    has_star = False
-    order_pos = 0
-
-    for keys_for_phoneme in components:
-        for letter in keys_for_phoneme:
-            if letter == "*":
-                has_star = True
-                continue
-            if len(stroke) > 0 and letter == stroke[-1]:
-                # We're repeating a letter; this is valid, just don't double
-                # the letter in the returned steno stroke.
-                continue
-
-            order_pos = config.STENO_ORDER.find(letter, order_pos)
-            if order_pos == -1:
-                if letter in config.STENO_ORDER:
-                    # The letter is out of steno order.
-                    return None
-
-                log = logging.getLogger("dictionary_generator")
-                log.error("Invalid symbol `%s` in steno stroke", letter)
-                return None
-
-            # This letter is a valid addition to the stroke.
-            stroke += letter
-
-    return (stroke, has_star)
+import steno
 
 
 def get_stroke_components(phonemes, phonemes_to_steno):
@@ -160,22 +32,21 @@ def get_stroke_components(phonemes, phonemes_to_steno):
     ways_to_stroke = [[]]
 
     for phoneme in phonemes:
-        steno = phonemes_to_steno[phoneme]
-        if steno is None:
+        ways_to_write_phoneme = phonemes_to_steno[phoneme]
+        if ways_to_write_phoneme is None:
             log.error("No mapping given for phoneme `%s` in `%s`", phoneme, phonemes)
-        elif steno == config.NO_STENO_MAPPING:
+        elif ways_to_write_phoneme == config.NO_STENO_MAPPING:
             log.error("No steno mapping for phoneme `%s` in `%s`", phoneme, phonemes)
             return None
-        elif isinstance(steno, list):
-            new_ways_to_stroke = []
-            for keys in steno:
-                for partial_stroke in ways_to_stroke:
-                    new_ways_to_stroke.append(partial_stroke + [keys])
 
-            ways_to_stroke = new_ways_to_stroke
-        else:
-            for prev_strokes in ways_to_stroke:
-                prev_strokes += [steno]
+        new_ways_to_stroke = []
+        for keys in ways_to_write_phoneme:
+            # Append the `keys` list to each list of how to stroke the previous
+            # components.
+            for partial_stroke in ways_to_stroke:
+                new_ways_to_stroke.append(partial_stroke + keys)
+
+        ways_to_stroke = new_ways_to_stroke
 
     return ways_to_stroke
 
@@ -192,6 +63,7 @@ def syllables_to_steno(syllables):
         steno key conversion in config.py.
     """
 
+    log = logging.getLogger("dictionary_generator")
     translations = []  # List of all ways to stroke the syllable sequence.
 
     for syllable in syllables:
@@ -228,34 +100,39 @@ def syllables_to_steno(syllables):
         ways_to_stroke_syllable = temp.copy()
 
         potential_strokes = []
-        for stroke_components in ways_to_stroke_syllable:
-            stroke = build_stroke_from_components(stroke_components)
-
-            if stroke is not None:
+        for keys_list in ways_to_stroke_syllable:
+            try:
+                stroke = steno.Stroke(keys_list)
+            except steno.OutOfStenoOrderError:
+                log.debug("Out of steno order `%s`", keys_list)
+            else:
                 potential_strokes.append(stroke)
 
         if len(potential_strokes) == 0:
-            log = logging.getLogger("dictionary_generator")
             log.info("No valid way to stroke the syllable `%s`", syllable)
             return None
 
         if len(translations) == 0:
-            translations = potential_strokes
+            # translations = potential_strokes
+            for stroke in potential_strokes:
+                translations.append(steno.StrokeSequence([stroke]))
         else:
             new_translations = []
-            for prev_strokes in translations:
+            for stroke_sequence in translations:
                 for stroke in potential_strokes:
-                    new_translations.append(prev_strokes + "/" + stroke)
+                    new_sequence = copy.deepcopy(stroke_sequence)
+                    new_sequence.append_stroke(stroke)
+                    new_translations.append(new_sequence)
 
             translations = new_translations.copy()
 
     # Run custom postprocessing.
     new_translations = []
-    for steno in translations:
-        new_steno = config.postprocess_steno_sequence(steno, syllables)
+    for stroke_sequence in translations:
+        new_stroke_sequence = config.postprocess_steno_sequence(stroke_sequence, syllables)
 
-        if new_steno is not None:
-            new_translations.append(new_steno)
+        if new_stroke_sequence is not None:
+            new_translations.append(new_stroke_sequence)
 
     translations = new_translations
 


### PR DESCRIPTION
The generated dicitonary is still the same, but this will make it easier later on to manipulate strokes.

Previously, strokes were represented by a string specifying which keys were pressed (e.g., "TKUBK") but since some consonants can appear on both the left and right sides, reasoning about which keys are actually intended was a bit tedious and error-prone.

With the revised structure there's a Stroke class that handles all of the internal details for keeping track of which keys are pressed, and a Key enum for unambiguously comparing keys even if they map to the same letter.