### PR TITLE
Specify dictionary generation rules via YAML config file

### DIFF
--- a/.github/workflows/python-styling.yml
+++ b/.github/workflows/python-styling.yml
@@ -21,6 +21,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pylint black
+        pip install -r requirements.txt
     - name: Analysing the code with pylint
       run: |
         min_allowed_lint_score_per_file=9.0

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Stenography is a fascinating and efficient way of writing, used by court reporte
 
 ## Table of Contents
 
-- [Requirements](#requirements)
+- [Installation and Requirements](#installation-and-requirements)
 - [Generate a Phonetic Dictionary](#generate-a-phonetic-dictionary)
   - [Usage](#usage)
   - [Default Theory](#default-theory)
@@ -22,7 +22,12 @@ Stenography is a fascinating and efficient way of writing, used by court reporte
 
 The code was designed to work with Python3.11. You can download Python from the official [Python webiste](https://www.python.org/downloads/).
 
-To install Steno Tools, run `git clone https://github.com/AndrewHess/steno-tools.git` in your terminal.
+In your terminal, run:
+```
+git clone https://github.com/AndrewHess/steno-tools.git
+cd steno-tools
+pip install -r requirements.txt
+```
 
 ## Generate a Phonetic Dictionary
 
@@ -39,36 +44,58 @@ To see usage options, run `python generate_phonetic_dictionary.py -h`. To write 
 
 ### Default Theory
 
-By default the mapping from phonemes to steno keys largely follows [Plover Theory](https://www.artofchording.com/introduction/theories-and-dictionaries.html#plover-theory). A few exceptions are that left-side `z` is formed by `SWR-` and right-side `v` is `-FB`. For a more complete mapping of phonemes to keys, open `config.py` and look at `VOWELS_TO_STENO`, `LEFT_CONSONANT_TO_STENO`, and `RIGHT_CONSONANT_TO_STENO`. The phonemes in those variables are specified via the [International Phonetic Alphabet](https://en.wikipedia.org/wiki/International_Phonetic_Alphabet) (IPA); if you're not familiar with IPA you can look at the variables `VOWELS` and `CONSONANTS` to see examples of each phoneme.
+By default the mapping from phonemes to steno keys largely follows [Plover Theory](https://www.artofchording.com/introduction/theories-and-dictionaries.html#plover-theory). A few exceptions are that left-side `z` is formed by `SWR-` and right-side `v` is `-FB`. For a more complete mapping of phonemes to keys, open `generator/configs/config.yaml` and look at the `vowels` and `consonants` sections. The phonemes in those sections are specified via the [International Phonetic Alphabet](https://en.wikipedia.org/wiki/International_Phonetic_Alphabet) (IPA). If you're not familiar with IPA you can look at the examples for each phoneme in `config.yaml`.
 
-Additionally, there's some postprocessing that's done by default. This consists of:
-1. For multistroke translations, if the vowel keys for the stroke consist only of `E`, `U`, or `EU` and the stroke is not the first stroke in the sequence, the vowels are removed from the stroke. For example, the generated stroke for `instead` will be `EUPB/ST-D` instead of `EUPB/STED`.
-2. Strokes can use the `-F` for a right-side `s` sound, but if the `s` sound is the last sound in the syllable it must be produced with the `-S` key.
-3. If the final stroke in a multistroke translation is `ʃən` (the `SHUN` sound in `ration`), that stroke is folded into the previous stroke by adding `-GS` to the previous stroke.
-4. If a non-final stroke in a stroke sequence consists entirely of `TK` plus `AOE`, `E`, `EU`, or `U`, the vowels are removed and the stroke becomes `TK-`. This is because those types of strokes can often be pronounced several of those ways (e.g., the first syllable of the word `develop`) and removing the vowels doesn't seem to add many conflicts.
+After strokes are generated phonetically, there some postprocessing that's done by default before writting the final dictionary. You can disable this postprocessing or specify your own rules in the `postprocessing` section. The default postprocessing consists of:
+1. Strokes can use the `-F` for a right-side `s` sound, but if the `s` sound is the last sound in the syllable it must be produced with the `-S` key.
+2. For multistroke translations, if the vowel keys for the stroke consist only of `E`, `U`, or `EU` and the stroke is not the first stroke in the sequence, the vowels are removed from the stroke. For example, the generated stroke for `instead` will be `EUPB/ST-D` instead of `EUPB/STED`.
+3. If the final stroke in a multistroke translation is `SHUPB` (the `SHUN` sound in `ration`), that stroke is folded into the previous stroke by adding `-GS` to the previous stroke.
+4. If a non-final stroke in a stroke sequence consists entirely of `TK-` plus `AOE`, `E`, `EU`, or `U`, the vowels are removed and the stroke becomes `TK-`. This is because those types of strokes can often be pronounced several of those ways (e.g., the first syllable of the word `develop`) and removing the vowels doesn't seem to add many conflicts.
 5. If a stroke sequence for one word is already used for a different word, the stroke `W-B` is repeatedly appended to the sequence until the sequence is unique.
 
 ### Customizing the Default Theory
 
-You can customize how words are mapped to strokes by modifying `generator/config.py`. You shouldn't need to change any other file for any reason[^1].
+The file `generator/configs/config.yaml` specifies how strokes are generated for words. You can update this file to customize the generated theory in almost any way.
+
+If you want to make a customization that's not covered in the following subsections, you'll have to make changes to the Python files. In that case, please consider making a pull request with the changes, or ask for the feature by raising a GitHub Issue so that more people can benefit from the desired feature.
 
 #### Customizing Phonemes
 
-The generator requires generated strokes to be in steno order. So in addition to the phonemes your language uses, you may want to add clusters of phonemes (e.g., a cluster for an ending `lp` sound because `-LP` is not in steno order so the generator could not make a stroke for words like `help`).
+The generator ensures generated strokes are in steno order. So in addition to the phonemes your language uses, you may want to add clusters of phonemes (e.g., a cluster for an ending `lp` sound because `-LP` is not in steno order so the generator could not make a stroke for words like `help`).
 
-In `config.py`, the `VOWELS` and `CONSONANTS` variables specify which phonemes are present in the language/dialect you're generating a dictionary for, and the `VOWELS_TO_STENO` and `LEFT_CONSONANT_TO_STENO`/`RIGHT_CONSONANT_TO_STENO` variables specify how to map those sounds to keys on a steno machine.
+In `config.yaml`, the `vowels` and `consonants` sections specify how phonemes are mapped to keys on a steno machine. The phoneme is specified with its IPA symbol(s) and the keys are specified as a list of ways to write that phoneme. Note that if the keys do not include a vowel or the asterisk key, you need to include a dash to show which side the consonant keys are one.
 
-To properly generate steno strokes, you need to ensure that the `VOWELS` and `CONSONANTS` variables contain all the vowel and consonant sounds for the language/dialect you're generating a dictionary for. The sounds are specified in IPA. Once these variables are set, for each entry in `VOWELS` you must add a corresponding entry to `VOWELS_TO_STENO`. Similarly, for each entry in `CONSONANTS` you must add a corresponding entry to both `LEFT_CONSONANT_TO_STENO` and `RIGHT_CONSONANT_TO_STENO`.
+In cases where it's not possible to produce a consonant sound on one side of the vowel, set the corresponding value for that sound on the unused side to `NO_STENO_MAPPING`.
 
-In cases where it's not possible to produce a consonant sound on one side of the vowel, set the corresponding value for that sound on the unused side to `NO_STENO_MAPPING`. If your theory allows multiple ways to make a certain sound (e.g., both `FT` and `*S` for an ending `st` sound), the entry for that side should be a list of all ways to map the sound to keys.
+If you change the list of phonemes in `consonants`, you'll need to update the `phonology` section as well, which specifies which consonant sounds coming before the vowel can follow each other. For context, the algorithm[^1] used to split a word into syllables is:
+1. Find all vowels; these make the nucleaus of each syllable.
+2. For each nucleus, form the syllable's onset by prepended as many of the leading consonants as possible while following the specified phonology rules.
+3. If there are any additional consonants before the vowel that could not be prepended to the onset, append those consonants to the previous syllable, forming the previous syllable's coda.
+
+So your updates in the `phonology` specify how step 2 is done.
 
 #### Postprocessing Strokes
 
-You may want to modify the generated strokes in a non-phonetic way. For example, to distinguish between homophones. There's two functions in `config.py` where you can add custom postprocessing: `postprocess_steno_sequence()` and `postprocess_generated_dictionary()`.
+For certain strokes, you may want to modify them before exporting them to the final dictionary. You can specify these rules in the `postprocessing` section of `config.yaml`. Additional information about setting up each of the rules mentioned below is available in the comments of the provided `config.yaml`.
 
-Add any postprocessing that is independent of other generated strokes to `postprocess_steno_sequence()`. For example, for words whose last syllable is `ʃən` (the `SHUN` sound in `ration`), you may want to fold that ending into the previous stroke by adding `-GS`.
+Many of the postprocessing steps have a `keep_original_sequence` key. When this is `True`, the original stroke is kept, and if postprocessing would change it, the changed versions are added to the dictionary. When `keep_original_sequence` is `False`, strokes that would not be changed by postprocessing are kept, but strokes that would get changed are replaced by the updated version.
 
-Add any postprocessing that is dependent on other generated strokes to `postprocess_generated_dictionary()`.  For example, you may want to remove conflicts where multiple words were given the same steno sequence. One way to solve this is by iterating through all of the steno sequences for all words and if that sequence is already used by a previous word, keep appending a disambiguation stroke until the sequence is unique.
+##### Disallow -F as Final S
+You may want to allow right-side `s` to be formed with the `-F` key if and only if there are other right-side keys in the stroke. If your `vowels` and `consonants` section is setup to allow `-F` as `s`, you can omit strokes that incorrectly use `-F` as the final `s` by enabling `disallow_f_for_final_s_sound`.
+
+##### Folding Strokes
+
+You may want to fold certain prefix and suffix strokes into the next/previous stroke. You can specify these rules in the `fold_strokes` section.
+
+##### Dropping Vowels
+
+You may find it useful to drop the vowels from certain strokes. You can specify when this should occur in the `drop_vowels` section.
+
+For each `drop_vowels` rule, you can specify what the left and right consonants should be for this rule to apply (or that they can be anything, or anything with at least one key), and you can specify which vowel clusters to drop. A vowel cluster is only dropped if it exactly matches the set of vowels in the stroke.
+
+##### Conflict Resolution
+
+You can enabled the `append_disambiguator_stroke` setting so that when two different words map to the same sequence of strokes, one of the sequences gets appended with a certain stroke until the resulting sequence has no conflicts. The `disambiguator_stroke` field specifies which stroke is appended. The sequence that gets appended to is the one that appears later in the file containing a list of words to generate strokes for; so if that list is sorted so more frequent words are at the top, then the sequence for the less frequent word will get appended to.
 
 ## Combine Dictionaries
 
@@ -88,4 +115,4 @@ This project is under the MIT License. See the `License` file for more info.
 
 Contributions are welcome! Please submit a pull request to contribute to this project. For bugs and feature requests, raise an Issue.
 
-[^1]: If you're generating strokes for a different language, then in addition to `generator/config.py` you may need to update how the IPA listing for a word is split into syllables; this is in `ipa_config.py`. The algorithm for splitting syllables is based on https://linguistics.stackexchange.com/questions/30933/how-to-split-ipa-spelling-into-syllables/30934#30934 and may not work for all languages.
+[^1]: The algorithm for splitting syllables is based on https://linguistics.stackexchange.com/questions/30933/how-to-split-ipa-spelling-into-syllables/30934#30934 and may not work for all languages. If you're generating strokes for a different language, then you may need to update how the IPA listing for a word is split into syllables; this is in `ipa_config.py`.

--- a/generator/configs/config.yaml
+++ b/generator/configs/config.yaml
@@ -1,0 +1,370 @@
+---  # Begin document.
+
+
+############################# Phonemes #############################
+
+# Vowel phonemes that may appear in the IPA pronunciation of words that you
+# want to generate steno strokes for.
+vowels:
+  ############ American English Vowels ############
+  - phoneme: "ɪ" # Ex: mYth, prEtty, wOmen
+    keys: ["EU"]
+  - phoneme: "ɛ" # Ex: brEAd, mAny, mEn
+    keys: ["E"]
+  - phoneme: "æ" # Ex: cAt, fAst, pAss
+    keys: ["A"]
+  - phoneme: "ə" # Ex: bUn, dOne, crUmb
+    keys: ["U"]
+  - phoneme: "ʊ" # Ex: wOOd, pUt
+    keys: ["AO"]
+  - phoneme: "i" # Ex: bEE, mEAt
+    keys: ["AOE"]
+  - phoneme: "ɔ" # Ex: brAWl, tAll, wrOUght, but not rot
+    keys: ["AU"]
+  - phoneme: "u" # Ex: fOOd, whO, blUE
+    keys: ["AOU"] # Note: this is the same as for 'ju'.
+  - phoneme: "ɝ" # Ex: pURR, pERson, dIRty, doctOR
+    keys: ["UR"]
+  - phoneme: "ɑ" # Ex: rOt, but not wrought
+    keys: ["O"]
+  - phoneme: "aɪ" # Ex: EYE, trY, nIght
+    keys: ["AOEU"]
+  - phoneme: "eɪ" # Ex: AYE, glAde
+    keys: ["AEU"]
+  - phoneme: "ɔɪ" # Ex: bOY, nOIse
+    keys: ["OEU"]
+  - phoneme: "aʊ" # Ex: clOWn, nOUn
+    keys: ["OU"]
+  - phoneme: "oʊ" # Ex: OWE, blOW
+    keys: ["OE"]
+  - phoneme: "ɪɹ" # Ex: fEAR, dEER, drEARy
+    keys: ["AOER"]
+  - phoneme: "ɛɹ" # Ex: AIR, glARe, stARE
+    keys: ["AEUR"]
+  - phoneme: "ɔɹ" # Ex: gORe, bOAR, dOOR
+    keys: ["OR"]
+  - phoneme: "ʊɹ" # Ex: pURe, ensURe
+    keys: ["AOUR"]
+  - phoneme: "ɑɹ" # Ex: cAR, sonAR, ARctic
+    keys: ["AR"]
+  ############ Extra Vowel Clusters ############
+  - phoneme: "ju" # Ex: YOU, fEW, pEWter
+    keys: ["AOU"] # Note: this is the same as for just 'u'.
+  - phoneme: "jə" # Sounds the same as 'ju' to me.
+    keys: ["AOU"]
+  - phoneme: "ɝtʃ" # Ex: lURCH, resEARCH
+    keys: ["UFRPB"]
+  - phoneme: "ɑɹtʃ" # Ex: ARCH, mARCH,
+    keys: ["AFRPB"]
+  - phoneme: "ɔɹtʃ" # Ex: tORCH, pORCH
+    keys: ["OFRPB"]
+
+# Consonant phonemes that may appear in the IPA pronunciation of words that
+# you want to generate steno strokes for. If you don't want to add a way to make
+# a certain phoneme with a certain side of the keyboard, set the value to
+# NO_STENO_MAPPING for that side.
+consonants:
+  ############ American English Consonants ############
+  - phoneme: "b"
+    keys_left: ["PW-"]
+    keys_right: ["-B"]
+  - phoneme: "d"
+    keys_left: ["TK-"]
+    keys_right: ["-D"]
+  - phoneme: "f"
+    keys_left: ["TP-"]
+    keys_right: ["-F"]
+  - phoneme: "h"
+    keys_left: ["H-"]
+    keys_right: NO_STENO_MAPPING
+  - phoneme: "j"  # This is a 'y' sound, like Yep, Yarn, You
+    keys_left: ["KWR-"]
+    keys_right: NO_STENO_MAPPING
+  - phoneme: "k"
+    keys_left: ["K-"]
+    keys_right: ["-BG"]
+  - phoneme: "m"
+    keys_left: ["PH-"]
+    keys_right: ["-PL"]
+  - phoneme: "n"
+    keys_left: ["TPH-"]
+    keys_right: ["-PB"]
+  - phoneme: "p"
+    keys_left: ["P-"]
+    keys_right: ["-P"]
+  - phoneme: "s"
+    keys_left: ["S-"]
+    keys_right: ["-S", "-F"]
+  - phoneme: "t"
+    keys_left: ["T-"]
+    keys_right: ["-T"]
+  - phoneme: "v"
+    keys_left: ["SR-"]
+    keys_right: ["-FB"]
+  - phoneme: "w"
+    keys_left: ["W-"]
+    keys_right: NO_STENO_MAPPING
+  - phoneme: "z"
+    keys_left: ["SWR-"]
+    keys_right: ["-Z"]
+  - phoneme: "ð" # Ex: worTHy, furTHer
+    keys_left: ["TH-"]
+    keys_right: ["*-T"]
+  - phoneme: "ŋ" # Ex: struNG, fliNG
+    keys_left: NO_STENO_MAPPING
+    keys_right: ["-PBG"]
+  - phoneme: "ɡ" # Ex: doG, Glue  Note: this is a UTF-8 character, not the letter G.
+    keys_left: ["TKPW-"]
+    keys_right: ["-G"]
+  - phoneme: "ɫ" # Ex: fiLL, terminaL
+    keys_left: ["HR-"]
+    keys_right: ["-L"]
+  - phoneme: "ɹ" # Ex: bRook, gRay
+    keys_left: ["R-"]
+    keys_right: ["-R"]
+  - phoneme: "ʃ" # Ex: wiSH, puSH
+    keys_left: ["SH-"]
+    keys_right: ["-RB"]
+  - phoneme: "ʒ" # Ex: leiSure, fuSion
+    keys_left: ["SKH-"]
+    keys_right: NO_STENO_MAPPING
+  - phoneme: "θ" # Ex: youTH, THin
+    keys_left: ["TH-"]
+    keys_right: ["*-T"]
+  - phoneme: "tʃ" # Ex: gliTCH, beaCH
+    keys_left: ["KH-"]
+    keys_right: ["-FP"]
+  - phoneme: "dʒ" # Ex: JuDGe, friDGe, Germ
+    keys_left: ["SKWR-"]
+    keys_right: ["-PBLG"]
+  ############ Consonant Clusters ############
+  - phoneme: "st" # Ex: firST heiST, burST
+    keys_left: ["ST-"]
+    keys_right: ["-FT", "*S"]
+  - phoneme: "ŋk" # Ex: baNK, thaNKs
+    keys_left: NO_STENO_MAPPING
+    keys_right: ["-PBG"]  # Note: this colides with '-ŋ'
+  - phoneme: "mp" # Ex: raMP, cluMP
+    keys_left: NO_STENO_MAPPING
+    keys_right: ["*PL"]
+  - phoneme: "ntʃ" # Ex: lauNCH, braNCH
+    keys_left: NO_STENO_MAPPING
+    keys_right: ["-FRPB"]
+
+
+############################# Phonology #############################
+
+# This section specifies which consonant phonemes can follow other consonant
+# phonemes before a vowel.
+phonology:
+  # Add your custom allowed rules to the below block.
+  - allowed:
+      # These sounds can come immediately before a vowel.
+      immediately_before_vowel: ["st"]
+
+      # If the previous sound is an element of `prev` and the next sound is an
+      # element of the corresponding `next` array, then `prev + next` is a
+      # valid consonant cluster before a vowel.
+      previous_and_next_sounds:
+        - prev: ["st"]
+          next: ["j", "w", "ɹ"]
+
+  # The below rules are from https://en.wikipedia.org/wiki/English_phonology
+  # You probably shouldn't change this unless:
+  #   1. There's an error or missing rule. Please raise a GitHub Issue or start
+  #      a pull request if that's the case.
+  #   2. You're generating strokes for a different language.
+  - allowed:
+      # These sounds can come immediately before a vowel.
+      immediately_before_vowel: [
+        "b", "d", "f", "h", "j", "k", "m", "n", "p", "s", "t", "v", "w", "z",
+        "ð", "ɡ", "ɫ", "ɹ", "ʃ", "ʒ", "θ", "tʃ", "dʒ"
+      ]
+
+      # If the previous sound is an element of `prev` and the next sound is an
+      # element of the corresponding `next` array, then `prev + next` is a
+      # valid consonant cluster before a vowel.
+      previous_and_next_sounds:
+        # Allow stop plus approximant other than 'j'.
+        - prev: ["p", "b", "k", "ɡ"]
+          next: ["ɫ"]
+        - prev: ["p", "b", "t", "d", "k", "ɡ"]
+          next: ["ɹ"]
+        - prev: ["p", "t", "d", "ɡ", "k"]
+          next: ["w"]
+
+        # Allow voicless fricative or 'v' plus approximant other than 'j'.
+        - prev: ["f", "s", "θ", "ʃ"]
+          next: ["ɫ"]
+        - prev: ["f", "θ", "ʃ"]
+          next: ["ɹ"]
+        - prev: ["h", "s", "θ", "v"]
+          next: ["w"]
+
+        # Allow consonants other than 'ɹ' and 'w' followed by 'j' (which should
+        # be followed by some form of 'u').
+        - prev: [
+            "b", "d", "f", "h", "k", "m", "n", "p", "s", "t", "v", "z","ð", "ɡ",
+            "ɫ", "ʃ", "ʒ", "θ", "tʃ", "dʒ"]
+          next: ["j"]
+
+        # Allow 's' plus voiceless stop.
+        - prev: ["s"]
+          next: ["p", "t", "k"]
+
+        # Allow 's' plus nasal other than 'ŋ'.
+        - prev: ["s"]
+          next: ["m", "n"]
+
+        # Allow 's' plus voiceless non-sibilant fricative.
+        - prev: ["s"]
+          next: ["f", "θ"]
+
+
+############################# Postprocessing #############################
+
+postprocessing:
+    # With this option enabled, a stroke ending in an 's' sound cannot end with
+    # the -F key even if the consonants section above specifies that right-side
+    # 's' can be made with -F.
+    disallow_f_for_final_s_sound:
+      enabled: True
+
+    # This section specifies rules for when a stroke can be folded into the
+    # next or previous stroke. This can be useful for prefix and suffix strokes.
+    # The elements of each rule are:
+    #   enabled: Whether this rule be checked for each stroke.
+    #   keep_original_sequence: When True and this rule applies, keep both the
+    #       original and new stroke sequences.
+    #   strokes_to_fold: A list of strokes. When a generated stroke matches any
+    #       stroke in this list, this rule applies to the stroke.
+    #   keys_to_fold_in: The keys that should be added to the next/previous
+    #       stroke when this rule applies. This stroke must include a dash if it
+    #       doesn't have an asterisk or any vowels.
+    #   fold_into: Either PREVIOUS_STROKE or NEXT_STROKE, specifying which
+    #       stroke the `keys_to_fold_in` will be added to. If the specified
+    #       stroke does not exist (e.g., the value is NEXT_STROKE, but this is
+    #       the last stroke in the sequence, so there is no next stroke in the
+    #       sequence), then this rule will not change the stroke.
+    fold_strokes:
+      enabled: True  # When False, none of the below rules will run.
+      rules:
+        # With this option enabled, when a non-starting stroke is SHUPB, the
+        # stroke is folded into the previous stroke as -GS.
+        - enabled: True
+          keep_original_sequence: False
+          strokes_to_fold: ["SHUPB"]
+          keys_to_fold_in: "-GS"
+          fold_into: PREVIOUS_STROKE
+
+        # With this option enabled, when a non-final stroke is KOPB, KUPB, KOPL,
+        # or KUPL, the stroke is folded into the next stroke as K-.
+        - enabled: False
+          keep_original_sequence: True
+          strokes_to_fold: ["KOPB", "KUPB", "KOPL", "KUPL"]
+          keys_to_fold_in: "K-"
+          fold_into: NEXT_STROKE
+
+    # This section specifies rules for when vowels should be removed from a
+    # stroke. This can be useful for some theories or when a syllable is often
+    # pronounced with several different vowels and removing those vowels from
+    # the stroke doesn't create a lot of conflicts.
+    # The elements of each rule are:
+    #   enabled: Whether this rule be checked for each stroke.
+    #   keep_original_sequence: When True and this rule applies, keep both the
+    #       original and new stroke sequences.
+    #   left_consonants: either ANY_SET_OF_KEYS, ANY_NON_EMPTY_SET_OF_KEYS, or
+    #       the actual keys that must exactly match the left consonants of the
+    #       stroke for the rule to apply. If its specifying the actual keys,
+    #       it must include a dash after the keys.
+    #   right_consonants: either ANY_SET_OF_KEYS, ANY_NON_EMPTY_SET_OF_KEYS, or
+    #       the actual keys that must exactly match the right consonants of the
+    #       stroke for the rule to apply. If its specifying the actual keys,
+    #       it must include a dash before the keys.
+    #   vowel_clusters_to_drop: A list of vowel clusters. The vowels for the
+    #       stroke are only dropped if they exactly match one of the elements
+    #       of this list.
+    #   enabled_for:
+    #       single_strokes: Whether this rule should be checked when a stroke
+    #           sequence consists of only a single stroke.
+    #       first_stroke_of_sequence: Whether this rule should be check when
+    #           the stroke is the first stroke in the stroke sequence.
+    #       middle_strokes_of_sequence: Whether this rule should be check when
+    #           the stroke is neither the first nor last stroke in the stroke
+    #           sequence.
+    #       last_stroke_of_sequence: Whether this rule should be check when
+    #           the stroke is the last stroke in the stroke sequence.
+    drop_vowels:
+      enabled: True
+      rules:
+        # With this option enabled, when a non-starting stroke in a stroke
+        # sequence has vowels that are only E, EU, or U, and there are
+        # right-side consonant, the vowels are removed from the stroke.
+        - enabled: True
+          keep_original_sequence: False
+          left_consonants: ANY_SET_OF_KEYS
+          right_consonants: ANY_NON_EMPTY_SET_OF_KEYS
+          vowel_clusters_to_drop: ["E", "EU", "U"]
+          enabled_for:
+            single_strokes: False
+            first_stroke_of_sequence: False
+            middle_strokes_of_sequence: True
+            last_stroke_of_sequence: True
+
+        # With this option enabled, when a stroke consists entirely of TK- plus
+        # some vowels and those vowels are AOE, E, EU, or U, the vowels are
+        # removed.
+        - enabled: True
+          keep_original_sequence: False
+          left_consonants: "TK-"
+          right_consonants: "-"
+          vowel_clusters_to_drop: ["AOE", "E", "EU", "U"]
+          enabled_for:
+            single_strokes: False
+            first_stroke_of_sequence: True
+            middle_strokes_of_sequence: True
+            last_stroke_of_sequence: False
+
+        # With this option enabled, when a stroke consists entirely of PW- plus
+        # some vowels and those vowels are AOE, E, EU, or U, the vowels are
+        # removed.
+        - enabled: False
+          keep_original_sequence: True
+          left_consonants: "PW-"
+          right_consonants: "-"
+          vowel_clusters_to_drop: ["AOE", "E", "EU", "U"]
+          enabled_for:
+            single_strokes: False
+            first_stroke_of_sequence: True
+            middle_strokes_of_sequence: True
+            last_stroke_of_sequence: False
+
+        # With this option enabled, when a stroke in the middle of a stroke
+        # sequence consists only of vowel keys, that stroke is removed.
+        - enabled: False
+          keep_original_sequence: True
+          left_consonants: "-"
+          right_consonants: "-"
+          vowel_clusters_to_drop: [
+            "A", "O", "E", "U", "AO", "AE", "AU", "OE", "OU", "AOE", "AOU", "OEU", "AOEU"
+          ]
+          enabled_for:
+            single_strokes: False
+            first_stroke_of_sequence: False
+            middle_strokes_of_sequence: True
+            last_stroke_of_sequence: False
+
+    # With this option enabled, when the same stroke sequence was generated for
+    # two different words, a stroke is repeatedly appended to one of the
+    # stroke sequences until it is unique.
+    #
+    # The stroke sequence that gets appended is the one for the word that
+    # appears later in the file continaing the words to generated strokes for.
+    # So if the words are sorted by higher frequecy closer to the top, then the
+    # less frequent word will get the extra stroke(s).
+    append_disambiguator_stroke:
+      enabled: True
+      disambiguator_stroke: "W-B"
+
+
+...  # End document.

--- a/generator/generate_phonetic_dictionary.py
+++ b/generator/generate_phonetic_dictionary.py
@@ -8,8 +8,9 @@ https://github.com/open-dict-data/ipa-dict
 
 import argparse
 import logging
+import sys
 
-import config
+from config import Config, InvalidConfigError
 import core
 
 
@@ -23,6 +24,12 @@ def get_args():
     parser.add_argument("ipa_file", type=str, help="the IPA CSV dictionary")
     parser.add_argument(
         "word_list_file", type=str, help="the file containing words generate strokes for"
+    )
+    parser.add_argument(
+        "--config_file",
+        type=str,
+        required=True,
+        help="the config file specifying how to generate strokes for words",
     )
     parser.add_argument(
         "-o", "--output_file", help="Path to the output file", default="output.json"
@@ -51,14 +58,14 @@ def main():
     logging.basicConfig(level=log_level, format=log_format)
     log = logging.getLogger("dictionary_generator")
 
-    # Make sure the config is valid.
-    if not core.vowel_to_steno_is_complete() or not core.consonant_to_steno_is_complete():
-        log.info("Not generating dictionary")
-        return
+    try:
+        config = Config(args.config_file)
+    except InvalidConfigError as err:
+        log.critical(err)
+        sys.exit(1)
 
     # Create the dictionary.
-    words_and_strokes = core.generate_dictionary(args.ipa_file, args.word_list_file)
-    words_and_strokes = config.postprocess_generated_dictionary(words_and_strokes)
+    words_and_strokes = core.generate_dictionary(args.ipa_file, args.word_list_file, config)
     core.write_dictionary_to_file(words_and_strokes, args.output_file)
 
 

--- a/generator/ipa_utils.py
+++ b/generator/ipa_utils.py
@@ -5,7 +5,6 @@ import random
 import re
 import sys
 
-import config
 from syllable import Syllable
 
 
@@ -94,7 +93,7 @@ def get_ipa_symbols(word_to_ipa):
     return symbols
 
 
-def split_ipa_into_syllables(ipa):
+def split_ipa_into_syllables(ipa, config):
     """Split the pronunciation of a word given by IPA into syllables.
 
     This function was designed for splitting English words into syllables, and
@@ -120,8 +119,8 @@ def split_ipa_into_syllables(ipa):
     # The vowels and consonants lists must be sorted so that entries with more
     # characters appear earlier. This is so that when we look for these
     # phonemes in an IPA definition, we match the longest phonemes if we can.
-    vowels = config.VOWELS
-    consonants = config.CONSONANTS
+    vowels = config.get_vowels()
+    consonants = config.get_consonants()
     vowels = sorted(vowels, key=len, reverse=True)
     consonants = sorted(consonants, key=len, reverse=True)
 
@@ -184,7 +183,8 @@ def split_ipa_into_syllables(ipa):
         # We need to iterate backwards since we'll be prepending.
         for k in range(len(onset_lst) - 1, -1, -1):
             phoneme = onset_lst[k]
-            if config.can_prepend_to_onset(phoneme, new_onset):
+            following_phoneme = new_onset[0] if len(new_onset) > 0 else None
+            if config.can_prepend_to_onset(phoneme, following_phoneme):
                 new_onset = [phoneme] + new_onset
             else:
                 if i == 0:

--- a/generator/postprocessing.py
+++ b/generator/postprocessing.py
@@ -1,0 +1,88 @@
+"""Tools for updating strokes after they've been generated.
+
+Changes that can be made without knowing about other strokes that were
+generated should be performed in postprocess_steno_sequence(), while changes
+that need to know about all other generated strokes should be made in
+postprocess_generated_dictionary().
+"""
+
+from steno import Key
+
+
+def postprocess_steno_sequence(stroke_sequence, syllables_ipa, config):
+    """Make custom modifications to a generated stroke sequence.
+
+    Args:
+        stroke_sequence: A StrokeSequence.
+        syllables_ipa: A list of Syllables, giving the pronunciation for the
+            translated word via IPA. See syllable.py for more info on a
+            Syllable.
+        config: The Config specifying how strokes should be generated.
+
+    Returns:
+        A list of updated StrokeSequences.
+    """
+
+    strokes = stroke_sequence.get_strokes()
+
+    if config.should_disallow_f_for_final_s_sound():
+        _disallow_f_for_final_s_sound(strokes, syllables_ipa)
+
+    return config.postprocess_stroke_sequence(stroke_sequence)
+
+
+def _disallow_f_for_final_s_sound(strokes, syllables_ipa):
+    """Disallow -F as the final 's' sound in a stroke.
+
+    If the final sound in a syllable is an 's', it should be with the 'S' key
+    not the 'F' key, even though making 's' with 'F' is allowed if there's
+    another sound later in the syllable.
+
+
+    Args:
+        strokes: a list of Strokes that correspond to one definition.
+        syllables_ipa: A list of Syllables, giving the pronunciation for the
+            translated word via IPA. See syllable.py for more info on a
+            Syllable.
+    """
+
+    for stroke, ipa in zip(strokes, syllables_ipa):
+        if stroke.get_last_key() == Key.RF and len(ipa.coda) > 0 and ipa.coda[-1] == "s":
+            # This is invalid.
+            strokes.clear()
+
+
+def postprocess_generated_dictionary(word_and_translations, config):
+    """Make custom modifications to the generated steno dictionary.
+
+    This can be used to resolve homophone conflicts for example, by looping
+    through all entries and checking if the the stroke sequence for the
+    current word is already taken and if so, appending some distinguishing
+    stroke to make it unique.
+
+    Args:
+        word_and_definitions: A list of tuples where the first item in each
+            tuple is the word to translate into steno and the second item in
+            the tuple is a StrokeSequences, with each StrokeSequence being a way
+            to write the word in steno.
+        config: The Config specifying how strokes should be generated.
+
+    Returns:
+        An updated version of the input after applying any modifications to the
+        each StrokeSequence.
+    """
+
+    if config.should_append_disambiguator_stroke():
+        # If a desired definition is already taken, append a the disambiguator
+        # stroke until it's unique.
+        used_translation_strings = set()
+        disambiguator_stroke = config.get_disambiguator_stroke()
+
+        for _, translations in word_and_translations:
+            for translation in translations:
+                while str(translation) in used_translation_strings:
+                    translation.append_stroke(disambiguator_stroke)
+
+                used_translation_strings.add(str(translation))
+
+    return word_and_translations

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+PyYAML==6.0
+schema==0.7.5


### PR DESCRIPTION
Now for the vast majority of cases, users will only need to update a YAML config file to customize how their dictionary is generated, instead of having to change a Python file.

Additionally, the YAML file sets up the configuration so that it should be straightforward to update the vowels and consonants mappings, update phonology rules, and create many useful custom postprocessing rules.