### PR TITLE
Configure dictionary generation rules with YAML file

### DIFF
--- a/.github/workflows/python-styling.yml
+++ b/.github/workflows/python-styling.yml
@@ -21,6 +21,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pylint black
+        pip install -r requirements.txt
     - name: Analysing the code with pylint
       run: |
         min_allowed_lint_score_per_file=9.0

--- a/README.md
+++ b/README.md
@@ -38,9 +38,15 @@ Steno Tools allows you to generate a phonetic steno dictionary by providing a li
 1. Download a CSV file that maps words to their pronunciation in IPA. A good choice is to go to https://github.com/open-dict-data/ipa-dict/releases/tag/1.0 and download the `csv.zip` file, unzip it, and extract the file for your language (e.g., `en_US.csv` for American English).
 2. Create a file containing the words that you want to include in the generated dictionary. There should be one word per line. A good option is to download the list of most frequently used English words from https://www.kaggle.com/datasets/rtatman/english-word-frequency and then clean it up by removing the comma and number after each word, capitalizing certain words, and anything else you want to do.
 3. In a terminal, go into the `generator` directory of this repository.
-4. Run `python generate_phonetic_dictionary.py /path/to/en_US.csv /path/to/your_word_list`.
+4. In a terminal, run
+```
+python generate_phonetic_dictionary.py /path/to/en_US.csv /path/to/your_word_list --config_file generator/configs/config.yaml
+```
+5. View the generated dictionary in `output.json`.
 
-To see usage options, run `python generate_phonetic_dictionary.py -h`. To write the emitted logs to `logs.txt` rather than standard output, append ` 2> logs.txt` to your command.
+To write the emitted logs to `logs.txt` rather than to the console, append ` 2> logs.txt` to your command.
+
+To see usage options, run `python generate_phonetic_dictionary.py -h`.
 
 ### Default Theory
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Stenography is a fascinating and efficient way of writing, used by court reporte
 
 ## Table of Contents
 
-- [Requirements](#requirements)
+- [Installation and Requirements](#installation-and-requirements)
 - [Generate a Phonetic Dictionary](#generate-a-phonetic-dictionary)
   - [Usage](#usage)
   - [Default Theory](#default-theory)
@@ -22,7 +22,12 @@ Stenography is a fascinating and efficient way of writing, used by court reporte
 
 The code was designed to work with Python3.11. You can download Python from the official [Python webiste](https://www.python.org/downloads/).
 
-To install Steno Tools, run `git clone https://github.com/AndrewHess/steno-tools.git` in your terminal.
+In your terminal, run:
+```
+git clone https://github.com/AndrewHess/steno-tools.git
+cd steno-tools
+pip install -r requirements.txt
+```
 
 ## Generate a Phonetic Dictionary
 
@@ -39,36 +44,58 @@ To see usage options, run `python generate_phonetic_dictionary.py -h`. To write 
 
 ### Default Theory
 
-By default the mapping from phonemes to steno keys largely follows [Plover Theory](https://www.artofchording.com/introduction/theories-and-dictionaries.html#plover-theory). A few exceptions are that left-side `z` is formed by `SWR-` and right-side `v` is `-FB`. For a more complete mapping of phonemes to keys, open `config.py` and look at `VOWELS_TO_STENO`, `LEFT_CONSONANT_TO_STENO`, and `RIGHT_CONSONANT_TO_STENO`. The phonemes in those variables are specified via the [International Phonetic Alphabet](https://en.wikipedia.org/wiki/International_Phonetic_Alphabet) (IPA); if you're not familiar with IPA you can look at the variables `VOWELS` and `CONSONANTS` to see examples of each phoneme.
+By default the mapping from phonemes to steno keys largely follows [Plover Theory](https://www.artofchording.com/introduction/theories-and-dictionaries.html#plover-theory). A few exceptions are that left-side `z` is formed by `SWR-` and right-side `v` is `-FB`. For a more complete mapping of phonemes to keys, open `generator/configs/config.yaml` and look at the `vowels` and `consonants` sections. The phonemes in those sections are specified via the [International Phonetic Alphabet](https://en.wikipedia.org/wiki/International_Phonetic_Alphabet) (IPA). If you're not familiar with IPA you can look at the examples for each phoneme in `config.yaml`.
 
-Additionally, there's some postprocessing that's done by default. This consists of:
-1. For multistroke translations, if the vowel keys for the stroke consist only of `E`, `U`, or `EU` and the stroke is not the first stroke in the sequence, the vowels are removed from the stroke. For example, the generated stroke for `instead` will be `EUPB/ST-D` instead of `EUPB/STED`.
-2. Strokes can use the `-F` for a right-side `s` sound, but if the `s` sound is the last sound in the syllable it must be produced with the `-S` key.
-3. If the final stroke in a multistroke translation is `ʃən` (the `SHUN` sound in `ration`), that stroke is folded into the previous stroke by adding `-GS` to the previous stroke.
-4. If a non-final stroke in a stroke sequence consists entirely of `TK` plus `AOE`, `E`, `EU`, or `U`, the vowels are removed and the stroke becomes `TK-`. This is because those types of strokes can often be pronounced several of those ways (e.g., the first syllable of the word `develop`) and removing the vowels doesn't seem to add many conflicts.
+After strokes are generated phonetically, there some postprocessing that's done by default before writting the final dictionary. You can disable this postprocessing or specify your own rules in the `postprocessing` section. The default postprocessing consists of:
+1. Strokes can use the `-F` for a right-side `s` sound, but if the `s` sound is the last sound in the syllable it must be produced with the `-S` key.
+2. For multistroke translations, if the vowel keys for the stroke consist only of `E`, `U`, or `EU` and the stroke is not the first stroke in the sequence, the vowels are removed from the stroke. For example, the generated stroke for `instead` will be `EUPB/ST-D` instead of `EUPB/STED`.
+3. If the final stroke in a multistroke translation is `SHUPB` (the `SHUN` sound in `ration`), that stroke is folded into the previous stroke by adding `-GS` to the previous stroke.
+4. If a non-final stroke in a stroke sequence consists entirely of `TK-` plus `AOE`, `E`, `EU`, or `U`, the vowels are removed and the stroke becomes `TK-`. This is because those types of strokes can often be pronounced several of those ways (e.g., the first syllable of the word `develop`) and removing the vowels doesn't seem to add many conflicts.
 5. If a stroke sequence for one word is already used for a different word, the stroke `W-B` is repeatedly appended to the sequence until the sequence is unique.
 
 ### Customizing the Default Theory
 
-You can customize how words are mapped to strokes by modifying `generator/config.py`. You shouldn't need to change any other file for any reason[^1].
+The file `generator/configs/config.yaml` specifies how strokes are generated for words. You can update this file to customize the generated theory in almost any way.
+
+If you want to make a customization that's not covered in the following subsections, you'll have to make changes to the Python files. In that case, please consider making a pull request with the changes, or ask for the feature by raising a GitHub Issue so that more people can benefit from the desired feature.
 
 #### Customizing Phonemes
 
-The generator requires generated strokes to be in steno order. So in addition to the phonemes your language uses, you may want to add clusters of phonemes (e.g., a cluster for an ending `lp` sound because `-LP` is not in steno order so the generator could not make a stroke for words like `help`).
+The generator ensures generated strokes are in steno order. So in addition to the phonemes your language uses, you may want to add clusters of phonemes (e.g., a cluster for an ending `lp` sound because `-LP` is not in steno order so the generator could not make a stroke for words like `help`).
 
-In `config.py`, the `VOWELS` and `CONSONANTS` variables specify which phonemes are present in the language/dialect you're generating a dictionary for, and the `VOWELS_TO_STENO` and `LEFT_CONSONANT_TO_STENO`/`RIGHT_CONSONANT_TO_STENO` variables specify how to map those sounds to keys on a steno machine.
+In `config.yaml`, the `vowels` and `consonants` sections specify how phonemes are mapped to keys on a steno machine. The phoneme is specified with its IPA symbol(s) and the keys are specified as a list of ways to write that phoneme. Note that if the keys do not include a vowel or the asterisk key, you need to include a dash to show which side the consonant keys are one.
 
-To properly generate steno strokes, you need to ensure that the `VOWELS` and `CONSONANTS` variables contain all the vowel and consonant sounds for the language/dialect you're generating a dictionary for. The sounds are specified in IPA. Once these variables are set, for each entry in `VOWELS` you must add a corresponding entry to `VOWELS_TO_STENO`. Similarly, for each entry in `CONSONANTS` you must add a corresponding entry to both `LEFT_CONSONANT_TO_STENO` and `RIGHT_CONSONANT_TO_STENO`.
+In cases where it's not possible to produce a consonant sound on one side of the vowel, set the corresponding value for that sound on the unused side to `NO_STENO_MAPPING`.
 
-In cases where it's not possible to produce a consonant sound on one side of the vowel, set the corresponding value for that sound on the unused side to `NO_STENO_MAPPING`. If your theory allows multiple ways to make a certain sound (e.g., both `FT` and `*S` for an ending `st` sound), the entry for that side should be a list of all ways to map the sound to keys.
+If you change the list of phonemes in `consonants`, you'll need to update the `phonology` section as well, which specifies which consonant sounds coming before the vowel can follow each other. For context, the algorithm[^1] used to split a word into syllables is:
+1. Find all vowels; these make the nucleaus of each syllable.
+2. For each nucleus, form the syllable's onset by prepended as many of the leading consonants as possible while following the specified phonology rules.
+3. If there are any additional consonants before the vowel that could not be prepended to the onset, append those consonants to the previous syllable, forming the previous syllable's coda.
+
+So your updates in the `phonology` specify how step 2 is done.
 
 #### Postprocessing Strokes
 
-You may want to modify the generated strokes in a non-phonetic way. For example, to distinguish between homophones. There's two functions in `config.py` where you can add custom postprocessing: `postprocess_steno_sequence()` and `postprocess_generated_dictionary()`.
+For certain strokes, you may want to modify them before exporting them to the final dictionary. You can specify these rules in the `postprocessing` section of `config.yaml`. Additional information about setting up each of the rules mentioned below is available in the comments of the provided `config.yaml`.
 
-Add any postprocessing that is independent of other generated strokes to `postprocess_steno_sequence()`. For example, for words whose last syllable is `ʃən` (the `SHUN` sound in `ration`), you may want to fold that ending into the previous stroke by adding `-GS`.
+Many of the postprocessing steps have a `keep_original_sequence` key. When this is `True`, the original stroke is kept, and if postprocessing would change it, the changed versions are added to the dictionary. When `keep_original_sequence` is `False`, strokes that would not be changed by postprocessing are kept, but strokes that would get changed are replaced by the updated version.
 
-Add any postprocessing that is dependent on other generated strokes to `postprocess_generated_dictionary()`.  For example, you may want to remove conflicts where multiple words were given the same steno sequence. One way to solve this is by iterating through all of the steno sequences for all words and if that sequence is already used by a previous word, keep appending a disambiguation stroke until the sequence is unique.
+##### Disallow -F as Final S
+You may want to allow right-side `s` to be formed with the `-F` key if and only if there are other right-side keys in the stroke. If your `vowels` and `consonants` section is setup to allow `-F` as `s`, you can omit strokes that incorrectly use `-F` as the final `s` by enabling `disallow_f_for_final_s_sound`.
+
+##### Folding Strokes
+
+You may want to fold certain prefix and suffix strokes into the next/previous stroke. You can specify these rules in the `fold_strokes` section.
+
+##### Dropping Vowels
+
+You may find it useful to drop the vowels from certain strokes. You can specify when this should occur in the `drop_vowels` section.
+
+For each `drop_vowels` rule, you can specify what the left and right consonants should be for this rule to apply (or that they can be anything, or anything with at least one key), and you can specify which vowel clusters to drop. A vowel cluster is only dropped if it exactly matches the set of vowels in the stroke.
+
+##### Conflict Resolution
+
+You can enabled the `append_disambiguator_stroke` setting so that when two different words map to the same sequence of strokes, one of the sequences gets appended with a certain stroke until the resulting sequence has no conflicts. The `disambiguator_stroke` field specifies which stroke is appended. The sequence that gets appended to is the one that appears later in the file containing a list of words to generate strokes for; so if that list is sorted so more frequent words are at the top, then the sequence for the less frequent word will get appended to.
 
 ## Combine Dictionaries
 
@@ -88,4 +115,4 @@ This project is under the MIT License. See the `License` file for more info.
 
 Contributions are welcome! Please submit a pull request to contribute to this project. For bugs and feature requests, raise an Issue.
 
-[^1]: If you're generating strokes for a different language, then in addition to `generator/config.py` you may need to update how the IPA listing for a word is split into syllables; this is in `ipa_config.py`. The algorithm for splitting syllables is based on https://linguistics.stackexchange.com/questions/30933/how-to-split-ipa-spelling-into-syllables/30934#30934 and may not work for all languages.
+[^1]: The algorithm for splitting syllables is based on https://linguistics.stackexchange.com/questions/30933/how-to-split-ipa-spelling-into-syllables/30934#30934 and may not work for all languages. If you're generating strokes for a different language, then you may need to update how the IPA listing for a word is split into syllables; this is in `ipa_config.py`.

--- a/generator/config.py
+++ b/generator/config.py
@@ -1,7 +1,9 @@
 """Configuration for the steno dictionary generator."""
 
 import logging
-import re
+
+import steno
+from steno import Key
 
 
 STENO_ORDER = "STKPWHRAOEUFRPBLGTSDZ"  # Excludes the '*'.
@@ -80,39 +82,38 @@ STRESS_MARKERS = ["ˈ", "ˌ"]
 #
 # Each vowel in VOWELS must have an entry here.
 #
-# If there are multiple ways to write the sound, the value should be a list of
-# strings with each string being a way to write it.
-#
-# If the sound should be stenoed with the star key, add a "*" character
-# anywhere in the string.
+# The value of each entry should be a list of ways to translate the phoneme to
+# steno; each way to translate it should itself be a list specifying the keys to
+# press and those keys should be in steno order. If the sound should be stenoed
+# with the star key, add Key.STAR anywhere in the inner list.
 VOWEL_TO_STENO = {
     ############ American English Vowels ############
-    "ɪ": "EU",
-    "ɛ": "E",
-    "æ": "A",
-    "ə": "U",
-    "ʊ": "AO",
-    "i": "AOE",
-    "ɔ": "AU",
-    "u": "AOU",  # Note: this is the same as for 'ju'.
-    "ɝ": "UR",
-    "ɑ": "O",
-    "aɪ": "AOEU",
-    "eɪ": "AEU",
-    "ɔɪ": "OEU",
-    "aʊ": "OU",
-    "oʊ": "OE",
-    "ɪɹ": "AOER",
-    "ɛɹ": "AEUR",
-    "ɔɹ": "OR",
-    "ʊɹ": "AOUR",
-    "ɑɹ": "AR",
+    "ɪ": [[Key.E, Key.U]],
+    "ɛ": [[Key.E]],
+    "æ": [[Key.A]],
+    "ə": [[Key.U]],
+    "ʊ": [[Key.A, Key.O]],
+    "i": [[Key.A, Key.O, Key.E]],
+    "ɔ": [[Key.A, Key.U]],
+    "u": [[Key.A, Key.O, Key.U]],  # Note: this is the same as for 'ju'.
+    "ɝ": [[Key.U, Key.RR]],
+    "ɑ": [[Key.O]],
+    "aɪ": [[Key.A, Key.O, Key.E, Key.U]],
+    "eɪ": [[Key.A, Key.E, Key.U]],
+    "ɔɪ": [[Key.O, Key.E, Key.U]],
+    "aʊ": [[Key.O, Key.U]],
+    "oʊ": [[Key.O, Key.E]],
+    "ɪɹ": [[Key.A, Key.O, Key.E, Key.RR]],
+    "ɛɹ": [[Key.A, Key.E, Key.U, Key.RR]],
+    "ɔɹ": [[Key.O, Key.RR]],
+    "ʊɹ": [[Key.A, Key.O, Key.U, Key.RR]],
+    "ɑɹ": [[Key.A, Key.RR]],
     ############ Extra Vowel Clusters ############
-    "ju": "AOU",  # Note: this is the same as for just 'u'.
-    "jə": "AOU",
-    "ɝtʃ": "UFRPB",
-    "ɑɹtʃ": "AFRPB",
-    "ɔɹtʃ": "OFRPB",
+    "ju": [[Key.A, Key.O, Key.U]],  # Note: this is the same as for just 'u'.
+    "jə": [[Key.A, Key.O, Key.U]],
+    "ɝtʃ": [[Key.U, Key.RF, Key.RR, Key.RP, Key.RB]],
+    "ɑɹtʃ": [[Key.A, Key.RF, Key.RR, Key.RP, Key.RB]],
+    "ɔɹtʃ": [[Key.O, Key.RF, Key.RR, Key.RP, Key.RB]],
 }
 
 # Specify how each consonant in CONSONANTS should be translated to steno using
@@ -121,37 +122,36 @@ VOWEL_TO_STENO = {
 # Each consonant in CONSONANTS must have an entry here; if it's not a valid
 # left-side consonant sound its value should be NO_STENO_MAPPING.
 #
-# If there are multiple ways to write the sound with left-side consonants, the
-# value should be a list of strings with each string being a way to write it.
-#
-# If the sound should be stenoed with the star key, add a "*" character
-# anywhere in the string.
+# The value of each entry should be a list of ways to translate the phoneme to
+# steno; each way to translate it should itself be a list specifying the keys to
+# press and those keys should be in steno order. If the sound should be stenoed
+# with the star key, add Key.STAR anywhere in the inner list.
 LEFT_CONSONANT_TO_STENO = {
-    "b": "PW",
-    "d": "TK",
-    "f": "TP",
-    "h": "H",
-    "j": "KWR",
-    "k": "K",
-    "m": "PH",
-    "n": "TPH",
-    "p": "P",
-    "s": "S",
-    "t": "T",
-    "v": "SR",
-    "w": "W",
-    "z": "SWR",
-    "ð": "TH",
+    "b": [[Key.LP, Key.LW]],
+    "d": [[Key.LT, Key.LK]],
+    "f": [[Key.LT, Key.LP]],
+    "h": [[Key.LH]],
+    "j": [[Key.LK, Key.LW, Key.LR]],
+    "k": [[Key.LK]],
+    "m": [[Key.LP, Key.LH]],
+    "n": [[Key.LT, Key.LP, Key.LH]],
+    "p": [[Key.LP]],
+    "s": [[Key.LS]],
+    "t": [[Key.LT]],
+    "v": [[Key.LS, Key.LR]],
+    "w": [[Key.LW]],
+    "z": [[Key.LS, Key.LW, Key.LR]],
+    "ð": [[Key.LT, Key.LH]],
     "ŋ": NO_STENO_MAPPING,
-    "ɡ": "TKPW",
-    "ɫ": "HR",
-    "ɹ": "R",
-    "ʃ": "SH",
-    "ʒ": "SKH",
-    "θ": "TH",
-    "tʃ": "KH",
-    "dʒ": "SKWR",
-    "st": "ST",
+    "ɡ": [[Key.LT, Key.LK, Key.LP, Key.LW]],
+    "ɫ": [[Key.LH, Key.LR]],
+    "ɹ": [[Key.LR]],
+    "ʃ": [[Key.LS, Key.LH]],
+    "ʒ": [[Key.LS, Key.LK, Key.LH]],
+    "θ": [[Key.LT, Key.LH]],
+    "tʃ": [[Key.LK, Key.LH]],
+    "dʒ": [[Key.LS, Key.LK, Key.LW, Key.LR]],
+    "st": [[Key.LS, Key.LT]],
     "ŋk": NO_STENO_MAPPING,
     "mp": NO_STENO_MAPPING,
     "ntʃ": NO_STENO_MAPPING,
@@ -163,40 +163,39 @@ LEFT_CONSONANT_TO_STENO = {
 # Each consonant in CONSONANTS must have an entry here; if it's not a valid
 # right-side consonant sound its value should be NO_STENO_MAPPING.
 #
-# If there are multiple ways to write the sound with right-side consonants, the
-# value should be a list of strings with each string being a way to write it.
-#
-# If the sound should be stenoed with the star key, add a "*" character
-# anywhere in the string.
+# The value of each entry should be a list of ways to translate the phoneme to
+# steno; each way to translate it should itself be a list specifying the keys to
+# press and those keys should be in steno order. If the sound should be stenoed
+# with the star key, add Key.STAR anywhere in the inner list.
 RIGHT_CONSONANT_TO_STENO = {
-    "b": "B",
-    "d": "D",
-    "f": "F",
+    "b": [[Key.RB]],
+    "d": [[Key.RD]],
+    "f": [[Key.RF]],
     "h": NO_STENO_MAPPING,
     "j": NO_STENO_MAPPING,
-    "k": "BG",
-    "m": "PL",
-    "n": "PB",
-    "p": "P",
-    "s": ["S", "F"],
-    "t": "T",
-    "v": "FB",
+    "k": [[Key.RB, Key.RG]],
+    "m": [[Key.RP, Key.RL]],
+    "n": [[Key.RP, Key.RB]],
+    "p": [[Key.RP]],
+    "s": [[Key.RS], [Key.RF]],
+    "t": [[Key.RT]],
+    "v": [[Key.RF, Key.RB]],
     "w": NO_STENO_MAPPING,
-    "z": "Z",
-    "ð": "*T",
-    "ŋ": "PBG",
-    "ɡ": "G",
-    "ɫ": "L",
-    "ɹ": "R",
-    "ʃ": "RB",
+    "z": [[Key.RZ]],
+    "ð": [[Key.STAR, Key.RT]],
+    "ŋ": [[Key.RP, Key.RB, Key.RG]],
+    "ɡ": [[Key.RG]],
+    "ɫ": [[Key.RL]],
+    "ɹ": [[Key.RR]],
+    "ʃ": [[Key.RR, Key.RB]],
     "ʒ": NO_STENO_MAPPING,
-    "θ": "*T",
-    "tʃ": "FP",
-    "dʒ": "PBLG",
-    "st": ["FT", "*S"],
-    "ŋk": "PBG",  # Note: this colides with 'ŋ'.
-    "mp": "*PL",
-    "ntʃ": "FRPB",
+    "θ": [[Key.STAR, Key.RT]],
+    "tʃ": [[Key.RF, Key.RP]],
+    "dʒ": [[Key.RP, Key.RB, Key.RL, Key.RG]],
+    "st": [[Key.RF, Key.RT], [Key.STAR, Key.RS]],
+    "ŋk": [[Key.RP, Key.RB, Key.RG]],  # Note: this colides with 'ŋ'.
+    "mp": [[Key.STAR, Key.RP, Key.RL]],
+    "ntʃ": [[Key.RF, Key.RR, Key.RP, Key.RB]],
 }
 
 
@@ -277,79 +276,76 @@ def can_prepend_to_onset(phoneme, onset):
     return False
 
 
-def postprocess_steno_sequence(steno_sequence, syllables_ipa):
+def postprocess_steno_sequence(stroke_sequence, syllables_ipa):
     """Make custom modifications to a generated stroke sequence.
 
     Args:
-        steno_sequence: a string specifying the generated steno strokes. Each
-            stroke is separated by a forward slash.
+        stroke_sequence: A StrokeSequence.
         syllables_ipa: A list of Syllables, giving the pronunciation for the
             translated word via IPA. See syllable.py for more info on a
             Syllable.
 
     Returns:
-        A string that is the stroke sequence after applying any modifications.
-        This should be the input `steno_sequence` if no modifications are
-        desired for this sequence.
+        The updated StrokeSequence to use. This should be the input
+        `stroke_sequence` if no modifications are desired for this sequence.
     """
 
-    syllables_steno = steno_sequence.split("/")
-    new_syllables_steno = syllables_steno.copy()
+    new_strokes = stroke_sequence.get_strokes().copy()
 
     # If a stroke after the first has 'U', 'EU', or 'E' as its vowel and it has
     # following consonants, replace the vowel cluster with '-' (or '*' if the
     # stroke is starred).
-    for i in range(1, len(syllables_steno)):
-        pattern = "([STKPWHR]*)([AO]*)([*]?)([EU]*)([FRPBLGTSDZ]*)"
-        match = re.match(pattern, syllables_steno[i])
+    for stroke in new_strokes[1:]:
+        active_vowels = stroke.get_vowels()
+        last_key = stroke.get_last_key()
 
-        if match:
-            (left, a_and_o, star, e_and_u, right) = match.groups()
-
-        if a_and_o == "" and len(e_and_u) != 0 and right != "":
-            # Remove the vowels.
-            middle = "*" if star == "*" else "-"
-            new_syllables_steno[i] = left + middle + right
+        if active_vowels in [[Key.E], [Key.E, Key.U], [Key.U]] and (
+            last_key is not None and last_key.index > Key.U.index
+        ):
+            stroke.clear_all_vowels()
 
     # If the final sound in a syllable is an 's', it should be with the 'S' key
     # not the 'F' key, even though making 's' with 'F' is allowed if there's
     # another sound later in the syllable.
-    for steno, ipa in zip(new_syllables_steno, syllables_ipa):
-        if steno[-1] == "F" and len(ipa.coda) > 0 and ipa.coda[-1] == "s":
+    for stroke, ipa in zip(new_strokes, syllables_ipa):
+        if stroke.get_last_key() == Key.RF and len(ipa.coda) > 0 and ipa.coda[-1] == "s":
             # This is invalid.
             return None
 
     # If the final stroke is 'SH-PB', fold it into the previous stroke as '-GS'.
-    if len(new_syllables_steno) > 1 and new_syllables_steno[-1] == "SH-PB":
-        prev = new_syllables_steno[-2]
-        if prev[-1] not in ["T", "D", "Z"] and "GS" not in prev:
-            # We can fold it in; just make sure not to repeat a key.
-            if prev[-1] == "G":
-                prev += "S"
-            elif prev[-1] == "S":
-                # We already know there's not a right-side 'T' or 'G', so we
-                # can put a 'G' immediately before the 'S'.
-                prev = prev[:-1] + "GS"
-            else:
-                prev += "GS"
+    shun_stroke = steno.Stroke([Key.LS, Key.LH, Key.RP, Key.RB])
+    if len(new_strokes) > 1 and new_strokes[-1] == shun_stroke:
+        prev_stroke = new_strokes[-2]
+        prev_stroke_keys = prev_stroke.get_keys()
+
+        if (
+            len(prev_stroke_keys) > 0
+            and prev_stroke_keys[-1] not in [Key.RT, Key.RD, Key.RZ]
+            and (Key.RG not in prev_stroke_keys or Key.RS not in prev_stroke_keys)
+        ):
+            prev_stroke.add_keys_maintain_steno_order([Key.RG, Key.RS])
 
             # Now actually replace the strokes.
-            new_syllables_steno = new_syllables_steno[:-1]
-            new_syllables_steno[-1] = prev
+            new_strokes = new_strokes[:-1]
 
     # If a stroke other than the last one in a multistroke entry conssists
     # entirely of 'TK' plus either 'AOE', 'E', 'EU', or 'U', then remvoe the
     # vowels. This is becuase such words (such as 'develop') can often be
     # pronunced in several of these ways.
-    for i, stroke in enumerate(new_syllables_steno[:-1]):
-        if len(stroke) > 2 and stroke[:2] == "TK" and stroke[2:] in ["AOE", "E", "EU", "U"]:
-            new_syllables_steno[i] = "TK-"
+    for stroke in new_strokes[:-1]:
+        stroke_str = str(stroke)
+        if (
+            len(stroke_str) > 2
+            and stroke_str[:2] == "TK"
+            and stroke_str[2:] in ["AOE", "E", "EU", "U"]
+        ):
+            stroke.clear_all_vowels()
 
-    return "/".join(new_syllables_steno)
+    return steno.StrokeSequence(new_strokes)
 
 
 # Perform custom postprocessing after the entire dictionary's been generated.
-def postprocess_generated_dictionary(word_and_definitions):
+def postprocess_generated_dictionary(word_and_translations):
     """Make custom modifications to the generated steno dictionary.
 
     This can be used to resolve homophone conflicts for example, by looping
@@ -360,25 +356,24 @@ def postprocess_generated_dictionary(word_and_definitions):
     Args:
         word_and_definitions: A list of tuples where the first item in each
             tuple is the word to translate into steno and the second item in
-            the tuple is a list of strings, with each string being a way to
-            write the word in steno.
+            the tuple is a StrokeSequences, with each StrokeSequence being a way
+            to write the word in steno.
 
     Returns:
-        A string that is the stroke sequence after applying any modifications.
-        This should be the input `steno_sequence` if no modifications are
-        desired for this sequence.
+        An updated version of the input after applying any modifications to the
+        each StrokeSequence.
     """
 
     # If a desired definition is already taken, append a 'W-B' stroke until
     # it's unique.
-    used_definitions = set()
+    used_translation_strs = set()
+    disambiguator_stroke = steno.Stroke([Key.LW, Key.RB])
 
-    for _, (_, definitions) in enumerate(word_and_definitions):
-        for k, strokes in enumerate(definitions):
-            while strokes in used_definitions:
-                strokes += "/W-B"
+    for _, translations in word_and_translations:
+        for translation in translations:
+            while str(translation) in used_translation_strs:
+                translation.append_stroke(disambiguator_stroke)
 
-            definitions[k] = strokes
-            used_definitions.add(strokes)
+            used_translation_strs.add(str(translation))
 
-    return word_and_definitions
+    return word_and_translations

--- a/generator/configs/config.yaml
+++ b/generator/configs/config.yaml
@@ -1,0 +1,370 @@
+---  # Begin document.
+
+
+############################# Phonemes #############################
+
+# Vowel phonemes that may appear in the IPA pronunciation of words that you
+# want to generate steno strokes for.
+vowels:
+  ############ American English Vowels ############
+  - phoneme: "ɪ" # Ex: mYth, prEtty, wOmen
+    keys: ["EU"]
+  - phoneme: "ɛ" # Ex: brEAd, mAny, mEn
+    keys: ["E"]
+  - phoneme: "æ" # Ex: cAt, fAst, pAss
+    keys: ["A"]
+  - phoneme: "ə" # Ex: bUn, dOne, crUmb
+    keys: ["U"]
+  - phoneme: "ʊ" # Ex: wOOd, pUt
+    keys: ["AO"]
+  - phoneme: "i" # Ex: bEE, mEAt
+    keys: ["AOE"]
+  - phoneme: "ɔ" # Ex: brAWl, tAll, wrOUght, but not rot
+    keys: ["AU"]
+  - phoneme: "u" # Ex: fOOd, whO, blUE
+    keys: ["AOU"] # Note: this is the same as for 'ju'.
+  - phoneme: "ɝ" # Ex: pURR, pERson, dIRty, doctOR
+    keys: ["UR"]
+  - phoneme: "ɑ" # Ex: rOt, but not wrought
+    keys: ["O"]
+  - phoneme: "aɪ" # Ex: EYE, trY, nIght
+    keys: ["AOEU"]
+  - phoneme: "eɪ" # Ex: AYE, glAde
+    keys: ["AEU"]
+  - phoneme: "ɔɪ" # Ex: bOY, nOIse
+    keys: ["OEU"]
+  - phoneme: "aʊ" # Ex: clOWn, nOUn
+    keys: ["OU"]
+  - phoneme: "oʊ" # Ex: OWE, blOW
+    keys: ["OE"]
+  - phoneme: "ɪɹ" # Ex: fEAR, dEER, drEARy
+    keys: ["AOER"]
+  - phoneme: "ɛɹ" # Ex: AIR, glARe, stARE
+    keys: ["AEUR"]
+  - phoneme: "ɔɹ" # Ex: gORe, bOAR, dOOR
+    keys: ["OR"]
+  - phoneme: "ʊɹ" # Ex: pURe, ensURe
+    keys: ["AOUR"]
+  - phoneme: "ɑɹ" # Ex: cAR, sonAR, ARctic
+    keys: ["AR"]
+  ############ Extra Vowel Clusters ############
+  - phoneme: "ju" # Ex: YOU, fEW, pEWter
+    keys: ["AOU"] # Note: this is the same as for just 'u'.
+  - phoneme: "jə" # Sounds the same as 'ju' to me.
+    keys: ["AOU"]
+  - phoneme: "ɝtʃ" # Ex: lURCH, resEARCH
+    keys: ["UFRPB"]
+  - phoneme: "ɑɹtʃ" # Ex: ARCH, mARCH,
+    keys: ["AFRPB"]
+  - phoneme: "ɔɹtʃ" # Ex: tORCH, pORCH
+    keys: ["OFRPB"]
+
+# Consonant phonemes that may appear in the IPA pronunciation of words that
+# you want to generate steno strokes for. If you don't want to add a way to make
+# a certain phoneme with a certain side of the keyboard, set the value to
+# NO_STENO_MAPPING for that side.
+consonants:
+  ############ American English Consonants ############
+  - phoneme: "b"
+    keys_left: ["PW-"]
+    keys_right: ["-B"]
+  - phoneme: "d"
+    keys_left: ["TK-"]
+    keys_right: ["-D"]
+  - phoneme: "f"
+    keys_left: ["TP-"]
+    keys_right: ["-F"]
+  - phoneme: "h"
+    keys_left: ["H-"]
+    keys_right: NO_STENO_MAPPING
+  - phoneme: "j"  # This is a 'y' sound, like Yep, Yarn, You
+    keys_left: ["KWR-"]
+    keys_right: NO_STENO_MAPPING
+  - phoneme: "k"
+    keys_left: ["K-"]
+    keys_right: ["-BG"]
+  - phoneme: "m"
+    keys_left: ["PH-"]
+    keys_right: ["-PL"]
+  - phoneme: "n"
+    keys_left: ["TPH-"]
+    keys_right: ["-PB"]
+  - phoneme: "p"
+    keys_left: ["P-"]
+    keys_right: ["-P"]
+  - phoneme: "s"
+    keys_left: ["S-"]
+    keys_right: ["-S", "-F"]
+  - phoneme: "t"
+    keys_left: ["T-"]
+    keys_right: ["-T"]
+  - phoneme: "v"
+    keys_left: ["SR-"]
+    keys_right: ["-FB"]
+  - phoneme: "w"
+    keys_left: ["W-"]
+    keys_right: NO_STENO_MAPPING
+  - phoneme: "z"
+    keys_left: ["SWR-"]
+    keys_right: ["-Z"]
+  - phoneme: "ð" # Ex: worTHy, furTHer
+    keys_left: ["TH-"]
+    keys_right: ["*-T"]
+  - phoneme: "ŋ" # Ex: struNG, fliNG
+    keys_left: NO_STENO_MAPPING
+    keys_right: ["-PBG"]
+  - phoneme: "ɡ" # Ex: doG, Glue  Note: this is a UTF-8 character, not the letter G.
+    keys_left: ["TKPW-"]
+    keys_right: ["-G"]
+  - phoneme: "ɫ" # Ex: fiLL, terminaL
+    keys_left: ["HR-"]
+    keys_right: ["-L"]
+  - phoneme: "ɹ" # Ex: bRook, gRay
+    keys_left: ["R-"]
+    keys_right: ["-R"]
+  - phoneme: "ʃ" # Ex: wiSH, puSH
+    keys_left: ["SH-"]
+    keys_right: ["-RB"]
+  - phoneme: "ʒ" # Ex: leiSure, fuSion
+    keys_left: ["SKH-"]
+    keys_right: NO_STENO_MAPPING
+  - phoneme: "θ" # Ex: youTH, THin
+    keys_left: ["TH-"]
+    keys_right: ["*-T"]
+  - phoneme: "tʃ" # Ex: gliTCH, beaCH
+    keys_left: ["KH-"]
+    keys_right: ["-FP"]
+  - phoneme: "dʒ" # Ex: JuDGe, friDGe, Germ
+    keys_left: ["SKWR-"]
+    keys_right: ["-PBLG"]
+  ############ Consonant Clusters ############
+  - phoneme: "st" # Ex: firST heiST, burST
+    keys_left: ["ST-"]
+    keys_right: ["-FT", "*S"]
+  - phoneme: "ŋk" # Ex: baNK, thaNKs
+    keys_left: NO_STENO_MAPPING
+    keys_right: ["-PBG"]  # Note: this colides with '-ŋ'
+  - phoneme: "mp" # Ex: raMP, cluMP
+    keys_left: NO_STENO_MAPPING
+    keys_right: ["*PL"]
+  - phoneme: "ntʃ" # Ex: lauNCH, braNCH
+    keys_left: NO_STENO_MAPPING
+    keys_right: ["-FRPB"]
+
+
+############################# Phonology #############################
+
+# This section specifies which consonant phonemes can follow other consonant
+# phonemes before a vowel.
+phonology:
+  # Add your custom allowed rules to the below block.
+  - allowed:
+      # These sounds can come immediately before a vowel.
+      immediately_before_vowel: ["st"]
+
+      # If the previous sound is an element of `prev` and the next sound is an
+      # element of the corresponding `next` array, then `prev + next` is a
+      # valid consonant cluster before a vowel.
+      previous_and_next_sounds:
+        - prev: ["st"]
+          next: ["j", "w", "ɹ"]
+
+  # The below rules are from https://en.wikipedia.org/wiki/English_phonology
+  # You probably shouldn't change this unless:
+  #   1. There's an error or missing rule. Please raise a GitHub Issue or start
+  #      a pull request if that's the case.
+  #   2. You're generating strokes for a different language.
+  - allowed:
+      # These sounds can come immediately before a vowel.
+      immediately_before_vowel: [
+        "b", "d", "f", "h", "j", "k", "m", "n", "p", "s", "t", "v", "w", "z",
+        "ð", "ɡ", "ɫ", "ɹ", "ʃ", "ʒ", "θ", "tʃ", "dʒ"
+      ]
+
+      # If the previous sound is an element of `prev` and the next sound is an
+      # element of the corresponding `next` array, then `prev + next` is a
+      # valid consonant cluster before a vowel.
+      previous_and_next_sounds:
+        # Allow stop plus approximant other than 'j'.
+        - prev: ["p", "b", "k", "ɡ"]
+          next: ["ɫ"]
+        - prev: ["p", "b", "t", "d", "k", "ɡ"]
+          next: ["ɹ"]
+        - prev: ["p", "t", "d", "ɡ", "k"]
+          next: ["w"]
+
+        # Allow voicless fricative or 'v' plus approximant other than 'j'.
+        - prev: ["f", "s", "θ", "ʃ"]
+          next: ["ɫ"]
+        - prev: ["f", "θ", "ʃ"]
+          next: ["ɹ"]
+        - prev: ["h", "s", "θ", "v"]
+          next: ["w"]
+
+        # Allow consonants other than 'ɹ' and 'w' followed by 'j' (which should
+        # be followed by some form of 'u').
+        - prev: [
+            "b", "d", "f", "h", "k", "m", "n", "p", "s", "t", "v", "z","ð", "ɡ",
+            "ɫ", "ʃ", "ʒ", "θ", "tʃ", "dʒ"]
+          next: ["j"]
+
+        # Allow 's' plus voiceless stop.
+        - prev: ["s"]
+          next: ["p", "t", "k"]
+
+        # Allow 's' plus nasal other than 'ŋ'.
+        - prev: ["s"]
+          next: ["m", "n"]
+
+        # Allow 's' plus voiceless non-sibilant fricative.
+        - prev: ["s"]
+          next: ["f", "θ"]
+
+
+############################# Postprocessing #############################
+
+postprocessing:
+    # With this option enabled, a stroke ending in an 's' sound cannot end with
+    # the -F key even if the consonants section above specifies that right-side
+    # 's' can be made with -F.
+    disallow_f_for_final_s_sound:
+      enabled: True
+
+    # This section specifies rules for when a stroke can be folded into the
+    # next or previous stroke. This can be useful for prefix and suffix strokes.
+    # The elements of each rule are:
+    #   enabled: Whether this rule be checked for each stroke.
+    #   keep_original_sequence: When True and this rule applies, keep both the
+    #       original and new stroke sequences.
+    #   strokes_to_fold: A list of strokes. When a generated stroke matches any
+    #       stroke in this list, this rule applies to the stroke.
+    #   keys_to_fold_in: The keys that should be added to the next/previous
+    #       stroke when this rule applies. This stroke must include a dash if it
+    #       doesn't have an asterisk or any vowels.
+    #   fold_into: Either PREVIOUS_STROKE or NEXT_STROKE, specifying which
+    #       stroke the `keys_to_fold_in` will be added to. If the specified
+    #       stroke does not exist (e.g., the value is NEXT_STROKE, but this is
+    #       the last stroke in the sequence, so there is no next stroke in the
+    #       sequence), then this rule will not change the stroke.
+    fold_strokes:
+      enabled: True  # When False, none of the below rules will run.
+      rules:
+        # With this option enabled, when a non-starting stroke is SHUPB, the
+        # stroke is folded into the previous stroke as -GS.
+        - enabled: True
+          keep_original_sequence: False
+          strokes_to_fold: ["SHUPB"]
+          keys_to_fold_in: "-GS"
+          fold_into: PREVIOUS_STROKE
+
+        # With this option enabled, when a non-final stroke is KOPB, KUPB, KOPL,
+        # or KUPL, the stroke is folded into the next stroke as K-.
+        - enabled: False
+          keep_original_sequence: True
+          strokes_to_fold: ["KOPB", "KUPB", "KOPL", "KUPL"]
+          keys_to_fold_in: "K-"
+          fold_into: NEXT_STROKE
+
+    # This section specifies rules for when vowels should be removed from a
+    # stroke. This can be useful for some theories or when a syllable is often
+    # pronounced with several different vowels and removing those vowels from
+    # the stroke doesn't create a lot of conflicts.
+    # The elements of each rule are:
+    #   enabled: Whether this rule be checked for each stroke.
+    #   keep_original_sequence: When True and this rule applies, keep both the
+    #       original and new stroke sequences.
+    #   left_consonants: either ANY_SET_OF_KEYS, ANY_NON_EMPTY_SET_OF_KEYS, or
+    #       the actual keys that must exactly match the left consonants of the
+    #       stroke for the rule to apply. If its specifying the actual keys,
+    #       it must include a dash after the keys.
+    #   right_consonants: either ANY_SET_OF_KEYS, ANY_NON_EMPTY_SET_OF_KEYS, or
+    #       the actual keys that must exactly match the right consonants of the
+    #       stroke for the rule to apply. If its specifying the actual keys,
+    #       it must include a dash before the keys.
+    #   vowel_clusters_to_drop: A list of vowel clusters. The vowels for the
+    #       stroke are only dropped if they exactly match one of the elements
+    #       of this list.
+    #   enabled_for:
+    #       single_strokes: Whether this rule should be checked when a stroke
+    #           sequence consists of only a single stroke.
+    #       first_stroke_of_sequence: Whether this rule should be check when
+    #           the stroke is the first stroke in the stroke sequence.
+    #       middle_strokes_of_sequence: Whether this rule should be check when
+    #           the stroke is neither the first nor last stroke in the stroke
+    #           sequence.
+    #       last_stroke_of_sequence: Whether this rule should be check when
+    #           the stroke is the last stroke in the stroke sequence.
+    drop_vowels:
+      enabled: True
+      rules:
+        # With this option enabled, when a non-starting stroke in a stroke
+        # sequence has vowels that are only E, EU, or U, and there are
+        # right-side consonant, the vowels are removed from the stroke.
+        - enabled: True
+          keep_original_sequence: False
+          left_consonants: ANY_SET_OF_KEYS
+          right_consonants: ANY_NON_EMPTY_SET_OF_KEYS
+          vowel_clusters_to_drop: ["E", "EU", "U"]
+          enabled_for:
+            single_strokes: False
+            first_stroke_of_sequence: False
+            middle_strokes_of_sequence: True
+            last_stroke_of_sequence: True
+
+        # With this option enabled, when a stroke consists entirely of TK- plus
+        # some vowels and those vowels are AOE, E, EU, or U, the vowels are
+        # removed.
+        - enabled: True
+          keep_original_sequence: False
+          left_consonants: "TK-"
+          right_consonants: "-"
+          vowel_clusters_to_drop: ["AOE", "E", "EU", "U"]
+          enabled_for:
+            single_strokes: False
+            first_stroke_of_sequence: True
+            middle_strokes_of_sequence: True
+            last_stroke_of_sequence: False
+
+        # With this option enabled, when a stroke consists entirely of PW- plus
+        # some vowels and those vowels are AOE, E, EU, or U, the vowels are
+        # removed.
+        - enabled: False
+          keep_original_sequence: True
+          left_consonants: "PW-"
+          right_consonants: "-"
+          vowel_clusters_to_drop: ["AOE", "E", "EU", "U"]
+          enabled_for:
+            single_strokes: False
+            first_stroke_of_sequence: True
+            middle_strokes_of_sequence: True
+            last_stroke_of_sequence: False
+
+        # With this option enabled, when a stroke in the middle of a stroke
+        # sequence consists only of vowel keys, that stroke is removed.
+        - enabled: False
+          keep_original_sequence: True
+          left_consonants: "-"
+          right_consonants: "-"
+          vowel_clusters_to_drop: [
+            "A", "O", "E", "U", "AO", "AE", "AU", "OE", "OU", "AOE", "AOU", "OEU", "AOEU"
+          ]
+          enabled_for:
+            single_strokes: False
+            first_stroke_of_sequence: False
+            middle_strokes_of_sequence: True
+            last_stroke_of_sequence: False
+
+    # With this option enabled, when the same stroke sequence was generated for
+    # two different words, a stroke is repeatedly appended to one of the
+    # stroke sequences until it is unique.
+    #
+    # The stroke sequence that gets appended is the one for the word that
+    # appears later in the file continaing the words to generated strokes for.
+    # So if the words are sorted by higher frequecy closer to the top, then the
+    # less frequent word will get the extra stroke(s).
+    append_disambiguator_stroke:
+      enabled: True
+      disambiguator_stroke: "W-B"
+
+
+...  # End document.

--- a/generator/core.py
+++ b/generator/core.py
@@ -64,13 +64,13 @@ def generate_dictionary(ipa_file, word_list_file):
             generated.
     Returns:
         A list of tuples where theh first item in each tuple is a word from
-        `word_list_file` and the second item in the tuple is a list of strings,
-        with each string being a way to write the word in steno.
+        `word_list_file` and the second item in the tuple is a list of
+        StrokeSequences, giving the valid ways to steno that word.
     """
 
     # Make a list of tuples. The first part of the tuple is the desired word,
     # and the second part is a list of ways to write it in steno.
-    words_and_strokes = []
+    words_and_translations = []
     word_to_ipa = ipa_utils.create_ipa_lookup_dictionary(ipa_file)
 
     num_words_requested = 0
@@ -83,7 +83,7 @@ def generate_dictionary(ipa_file, word_list_file):
             num_words_requested += 1
             word = line.strip()
             word_lower = word.lower()
-            word_in_steno = []  # A list of ways to write the word.
+            translations_for_word = []  # A list of ways to write the word.
 
             log.debug("Translating `%s`", word)
 
@@ -101,15 +101,15 @@ def generate_dictionary(ipa_file, word_list_file):
                 translations = stroke_builder.syllables_to_steno(syllables)
                 if translations is not None:
                     log.debug("Generated %s for `%s`", translations, word)
-                    word_in_steno += translations
+                    translations_for_word += translations
 
-            # Remove duplicate steno sequences.
-            word_in_steno = list(set(word_in_steno))
+            # Remove duplicate translations.
+            translations_for_word = sorted(list(set(translations_for_word)))
 
-            if len(word_in_steno) == 0:
+            if len(translations_for_word) == 0:
                 log.warning("No translation for `%s`", word)
             else:
-                words_and_strokes.append((word, word_in_steno))
+                words_and_translations.append((word, translations_for_word))
                 num_words_translated += 1
 
     print(
@@ -117,14 +117,14 @@ def generate_dictionary(ipa_file, word_list_file):
         + f"{num_words_requested} words"
     )
 
-    return words_and_strokes
+    return words_and_translations
 
 
-def write_dictionary_to_file(words_and_strokes, output_file):
+def write_dictionary_to_file(words_and_translations, output_file):
     """Write steno strokes for words to a file in JSON format.
 
     Args:
-        words_and_strokes: the returned value from generate_dictionary()
+        words_and_translations: the returned value from generate_dictionary().
         output_file: the name of the output file. This should be a JSON file.
     """
 
@@ -134,16 +134,16 @@ def write_dictionary_to_file(words_and_strokes, output_file):
     with open(output_file, "w+", encoding="UTF-8") as output:
         output.write("{\n")
 
-        for i, (word, ways_to_stroke) in enumerate(words_and_strokes):
-            for k, strokes in enumerate(ways_to_stroke):
-                line = f'"{strokes}": "{word}"'
-                if i < len(words_and_strokes) - 1 or k < len(ways_to_stroke) - 1:
+        for i, (word, translations) in enumerate(words_and_translations):
+            for k, stroke_sequence in enumerate(translations):
+                line = f'"{str(stroke_sequence)}": "{word}"'
+                if i < len(words_and_translations) - 1 or k < len(translations) - 1:
                     line += ","
 
                 output.write(f"{line}\n")
 
                 num_entries += 1
-                num_strokes += 1 + strokes.count("/")
+                num_strokes += len(stroke_sequence.get_strokes())
 
         output.write("}")
 

--- a/generator/generate_phonetic_dictionary.py
+++ b/generator/generate_phonetic_dictionary.py
@@ -8,8 +8,9 @@ https://github.com/open-dict-data/ipa-dict
 
 import argparse
 import logging
+import sys
 
-import config
+from config import Config, InvalidConfigError
 import core
 
 
@@ -23,6 +24,12 @@ def get_args():
     parser.add_argument("ipa_file", type=str, help="the IPA CSV dictionary")
     parser.add_argument(
         "word_list_file", type=str, help="the file containing words generate strokes for"
+    )
+    parser.add_argument(
+        "--config_file",
+        type=str,
+        required=True,
+        help="the config file specifying how to generate strokes for words",
     )
     parser.add_argument(
         "-o", "--output_file", help="Path to the output file", default="output.json"
@@ -51,14 +58,14 @@ def main():
     logging.basicConfig(level=log_level, format=log_format)
     log = logging.getLogger("dictionary_generator")
 
-    # Make sure the config is valid.
-    if not core.vowel_to_steno_is_complete() or not core.consonant_to_steno_is_complete():
-        log.info("Not generating dictionary")
-        return
+    try:
+        config = Config(args.config_file)
+    except InvalidConfigError as err:
+        log.critical(err)
+        sys.exit(1)
 
     # Create the dictionary.
-    words_and_strokes = core.generate_dictionary(args.ipa_file, args.word_list_file)
-    words_and_strokes = config.postprocess_generated_dictionary(words_and_strokes)
+    words_and_strokes = core.generate_dictionary(args.ipa_file, args.word_list_file, config)
     core.write_dictionary_to_file(words_and_strokes, args.output_file)
 
 

--- a/generator/ipa_utils.py
+++ b/generator/ipa_utils.py
@@ -5,7 +5,6 @@ import random
 import re
 import sys
 
-import config
 from syllable import Syllable
 
 
@@ -94,7 +93,7 @@ def get_ipa_symbols(word_to_ipa):
     return symbols
 
 
-def split_ipa_into_syllables(ipa):
+def split_ipa_into_syllables(ipa, config):
     """Split the pronunciation of a word given by IPA into syllables.
 
     This function was designed for splitting English words into syllables, and
@@ -120,8 +119,8 @@ def split_ipa_into_syllables(ipa):
     # The vowels and consonants lists must be sorted so that entries with more
     # characters appear earlier. This is so that when we look for these
     # phonemes in an IPA definition, we match the longest phonemes if we can.
-    vowels = config.VOWELS
-    consonants = config.CONSONANTS
+    vowels = config.get_vowels()
+    consonants = config.get_consonants()
     vowels = sorted(vowels, key=len, reverse=True)
     consonants = sorted(consonants, key=len, reverse=True)
 
@@ -184,7 +183,8 @@ def split_ipa_into_syllables(ipa):
         # We need to iterate backwards since we'll be prepending.
         for k in range(len(onset_lst) - 1, -1, -1):
             phoneme = onset_lst[k]
-            if config.can_prepend_to_onset(phoneme, new_onset):
+            following_phoneme = new_onset[0] if len(new_onset) > 0 else None
+            if config.can_prepend_to_onset(phoneme, following_phoneme):
                 new_onset = [phoneme] + new_onset
             else:
                 if i == 0:

--- a/generator/postprocessing.py
+++ b/generator/postprocessing.py
@@ -1,0 +1,88 @@
+"""Tools for updating strokes after they've been generated.
+
+Changes that can be made without knowing about other strokes that were
+generated should be performed in postprocess_steno_sequence(), while changes
+that need to know about all other generated strokes should be made in
+postprocess_generated_dictionary().
+"""
+
+from steno import Key
+
+
+def postprocess_steno_sequence(stroke_sequence, syllables_ipa, config):
+    """Make custom modifications to a generated stroke sequence.
+
+    Args:
+        stroke_sequence: A StrokeSequence.
+        syllables_ipa: A list of Syllables, giving the pronunciation for the
+            translated word via IPA. See syllable.py for more info on a
+            Syllable.
+        config: The Config specifying how strokes should be generated.
+
+    Returns:
+        A list of updated StrokeSequences.
+    """
+
+    strokes = stroke_sequence.get_strokes()
+
+    if config.should_disallow_f_for_final_s_sound():
+        _disallow_f_for_final_s_sound(strokes, syllables_ipa)
+
+    return config.postprocess_stroke_sequence(stroke_sequence)
+
+
+def _disallow_f_for_final_s_sound(strokes, syllables_ipa):
+    """Disallow -F as the final 's' sound in a stroke.
+
+    If the final sound in a syllable is an 's', it should be with the 'S' key
+    not the 'F' key, even though making 's' with 'F' is allowed if there's
+    another sound later in the syllable.
+
+
+    Args:
+        strokes: a list of Strokes that correspond to one definition.
+        syllables_ipa: A list of Syllables, giving the pronunciation for the
+            translated word via IPA. See syllable.py for more info on a
+            Syllable.
+    """
+
+    for stroke, ipa in zip(strokes, syllables_ipa):
+        if stroke.get_last_key() == Key.RF and len(ipa.coda) > 0 and ipa.coda[-1] == "s":
+            # This is invalid.
+            strokes.clear()
+
+
+def postprocess_generated_dictionary(word_and_translations, config):
+    """Make custom modifications to the generated steno dictionary.
+
+    This can be used to resolve homophone conflicts for example, by looping
+    through all entries and checking if the the stroke sequence for the
+    current word is already taken and if so, appending some distinguishing
+    stroke to make it unique.
+
+    Args:
+        word_and_definitions: A list of tuples where the first item in each
+            tuple is the word to translate into steno and the second item in
+            the tuple is a StrokeSequences, with each StrokeSequence being a way
+            to write the word in steno.
+        config: The Config specifying how strokes should be generated.
+
+    Returns:
+        An updated version of the input after applying any modifications to the
+        each StrokeSequence.
+    """
+
+    if config.should_append_disambiguator_stroke():
+        # If a desired definition is already taken, append a the disambiguator
+        # stroke until it's unique.
+        used_translation_strings = set()
+        disambiguator_stroke = config.get_disambiguator_stroke()
+
+        for _, translations in word_and_translations:
+            for translation in translations:
+                while str(translation) in used_translation_strings:
+                    translation.append_stroke(disambiguator_stroke)
+
+                used_translation_strings.add(str(translation))
+
+    return word_and_translations

--- a/generator/steno.py
+++ b/generator/steno.py
@@ -1,0 +1,283 @@
+"""Manage steno keys, strokes, and sequences of strokes."""
+
+from enum import Enum
+
+
+class MissingDashInStrokeError(Exception):
+    """Error for when a steno stroke string is missing a middle.
+
+    This should be thrown when a string representing a stroke doesn't have any
+    vowels and also doesn't have an asterisk.
+    """
+
+
+class OutOfStenoOrderError(Exception):
+    """Error for when the keys of a steno stroke are out of order."""
+
+
+class Key(Enum):
+    """Enum for the keys on a steno keyboard."""
+
+    NUM = (0, "#")
+    LS = (1, "S")
+    LT = (2, "T")
+    LK = (3, "K")
+    LP = (4, "P")
+    LW = (5, "W")
+    LH = (6, "H")
+    LR = (7, "R")
+    A = (8, "A")
+    O = (9, "O")
+    STAR = (10, "*")
+    E = (11, "E")
+    U = (12, "U")
+    RF = (13, "F")
+    RR = (14, "R")
+    RP = (15, "P")
+    RB = (16, "B")
+    RL = (17, "L")
+    RG = (18, "G")
+    RT = (19, "T")
+    RS = (20, "S")
+    RD = (21, "D")
+    RZ = (22, "Z")
+
+    def __init__(self, index, letter):
+        self.index = index
+        self.letter = letter
+
+
+class Stroke:
+    """A single steno stroke."""
+
+    def __init__(self, keys=None):
+        self._active_keys_bitmap = [False] * len(Key)
+        self._last_active_pos = -1
+
+        if keys is not None:
+            self.add_keys_maintain_steno_order(keys)
+
+    def __eq__(self, other):
+        if self._last_active_pos != other._last_active_pos:
+            return False
+
+        return self._active_keys_bitmap == other._active_keys_bitmap
+
+    def __lt__(self, other):
+        for i, (active_self, active_other) in enumerate(
+            zip(self._active_keys_bitmap, other._active_keys_bitmap)
+        ):
+            if active_self and not active_other:
+                return other._last_active_pos > i
+
+            if active_other and not active_self:
+                return self._last_active_pos < i
+
+        return False
+
+    def __hash__(self):
+        return hash(tuple(self._active_keys_bitmap))
+
+    def __str__(self):
+        result = ""
+        has_vowel_or_star = False
+
+        for key in Key:
+            if self._active_keys_bitmap[key.index]:
+                result += key.letter
+
+                if key.letter in ["A", "O", "*", "E", "U"]:
+                    has_vowel_or_star = True
+
+            if key is Key.U and not has_vowel_or_star:
+                result += "-"
+
+        return result
+
+    @staticmethod
+    def from_string(stroke_str):
+        """Create a stroke from its string representation.
+
+        If the input string doesn't contain any vowels or an asterisk, it must
+        include a "-" to indicate separation between the left and right
+        consonants, even if only consonants on one side are present in the
+        stroke.
+
+        Args:
+            stroke_str: A string representing a single steno stroke. For
+                example, "TP*EURS", "S-P".
+
+        Raises:
+            MissingDashInStrokeError: If the input string doesn't have any
+                vowels and it doesn't have an asterisk and it doens't have a
+                dash to denote the split between left and right consonants.
+            OutOfStenoOrderError: If the keys in the input string are out of
+                steno order.
+
+        Returns:
+            The stroke corresponding to the input string.
+        """
+
+        keys = []
+        past_middle = False
+
+        for key_str in stroke_str:
+            if key_str == "-":
+                past_middle = True
+                continue
+
+            if key_str == "#":
+                keys.append(Key.NUM)
+                continue
+
+            for key in [Key.A, Key.O, Key.STAR, Key.E, Key.U]:
+                if key_str == key.letter:
+                    past_middle = True
+                    keys.append(key)
+                    break
+
+            consonants = [Key.LS, Key.LT, Key.LK, Key.LP, Key.LW, Key.LH, Key.LR]
+            if past_middle:
+                consonants = [
+                    Key.RF,
+                    Key.RR,
+                    Key.RP,
+                    Key.RB,
+                    Key.RL,
+                    Key.RG,
+                    Key.RT,
+                    Key.RS,
+                    Key.RD,
+                    Key.RZ,
+                ]
+
+            for key in consonants:
+                if key_str == key.letter:
+                    keys.append(key)
+                    break
+
+        if not past_middle:
+            raise MissingDashInStrokeError()
+
+        return Stroke(keys=keys)
+
+    def add_keys_maintain_steno_order(self, keys):
+        """Add keys to this stroke while ensuring steno order is maintained.
+
+        Args:
+            keys: list(Key)
+
+        Raises:
+            OutOfStenoOrderError: If appending the keys to the stroke would put
+            the stroke out of steno order.
+        """
+
+        for key in keys:
+            if key not in [Key.NUM, Key.STAR]:
+                if key.index < self._last_active_pos:
+                    raise OutOfStenoOrderError()
+
+                self._last_active_pos = key.index
+
+            self._active_keys_bitmap[key.index] = True
+
+    def clear_keys(self, keys):
+        """Removes the specified keys from this stroke.
+
+        This works even if some of the keys are not already in the stroke.
+
+        Args:
+            keys: list(Key)
+        """
+
+        for key in keys:
+            self._active_keys_bitmap[key.index] = False
+
+        # Update `self._last_active_pos`.
+        self._last_active_pos = -1
+        for key in reversed(Key):
+            if self._active_keys_bitmap[key.index] and key not in [Key.NUM, Key.STAR]:
+                self._last_active_pos = key.index
+                break
+
+    def clear_all_vowels(self):
+        """Remove all vowels from this stroke."""
+
+        self.clear_keys([Key.A, Key.O, Key.E, Key.U])
+
+    def get_vowels(self):
+        """Return the list of vowel keys in this stroke."""
+
+        active_vowels = []
+
+        for key in [Key.A, Key.O, Key.E, Key.U]:
+            if self._active_keys_bitmap[key.index]:
+                active_vowels.append(key)
+
+        return active_vowels
+
+    def get_last_key(self):
+        """Return the last key in this stroke, or None if there are no keys."""
+
+        if self._last_active_pos == -1:
+            return None
+
+        return list(Key)[self._last_active_pos]
+
+    def get_keys(self):
+        """Return the list of keys present in this stroke."""
+
+        keys = []
+
+        for key in Key:
+            if self._active_keys_bitmap[key.index]:
+                keys.append(key)
+
+        return keys
+
+
+class StrokeSequence:
+    """A series of Strokes, meant to represent one translation."""
+
+    def __init__(self, strokes=None):
+        self._strokes = strokes if strokes is not None else []
+
+    def __eq__(self, other):
+        return self._strokes == other._strokes
+
+    def __hash__(self):
+        return hash(tuple(self._strokes))
+
+    def __lt__(self, other):
+        if len(self._strokes) < len(other._strokes):
+            return True
+
+        if len(self._strokes) > len(other._strokes):
+            return False
+
+        for stroke1, stroke2 in zip(self._strokes, other._strokes):
+            if stroke1 < stroke2:
+                return True
+
+            if stroke1 > stroke2:
+                return False
+
+        return False
+
+    def __str__(self):
+        return "/".join([str(stroke) for stroke in self._strokes])
+
+    def get_strokes(self):
+        """Return the list of strokes comprising this sequence."""
+
+        return self._strokes
+
+    def append_stroke(self, stroke):
+        """Append a stroke to this sequence."""
+
+        self._strokes.append(stroke)
+
+    def set_strokes(self, strokes):
+        """Overwrite this sequence with the provided list of strokes."""
+
+        self._strokes = strokes

--- a/generator/stroke_builder.py
+++ b/generator/stroke_builder.py
@@ -1,138 +1,10 @@
 """Convert IPA syllables into steno strokes."""
 
+import copy
 import logging
 
 import config
-
-
-# Each of the parameters is a list of keys to stroke. Each element of each
-# paramter is the keys corresponding to one phoneme in the syllable.
-def build_stroke_from_components(components):
-    """Create a steno stroke from a list of components of the stroke.
-
-    Example:
-        components = ["PB", "OE", "*T"]
-        returns "PBO*ET"
-
-    If any component has a "*" in any position, then the returned stroke will
-    have a "*" in the correct position, otherwise it will not have a star.
-
-    Note: This function requires that one of the components has at least one
-    vowels character (A, O, E, or U).
-
-    Args:
-        Components: A list of steno stroke components. Each element of the list
-            is a string specifying keys to add to the stroke, and any element
-            may contain a "*" anywhere to indicate that a "*" should be added
-            to the correct position in the stroke.
-
-    Returns:
-        A string that is the concatenation of `components` but with the "*" (if
-        any) placed in the correct place.
-        If concatenating `components` would give a stroke that is out of steno
-        order, then None is returned instead.
-    """
-
-    log = logging.getLogger("dictionary_generator")
-    info = build_stroke_helper(components)
-
-    if info is None:
-        return None
-
-    (stroke, has_star) = info
-
-    # Make sure there's a vowel key. If there aren't any, then we need to place
-    # a '-' where the vowels would be. However, the logic gets a bit tricky
-    # because some consonants are on both the left and right sides. So to make
-    # it easier and becuase all English syllables have vowels, I'm going to
-    # require that each stroke as a vowel key.
-    has_vowel = False
-    for vowel in ["A", "O", "E", "U"]:
-        if vowel in stroke:
-            has_vowel = True
-
-    if not has_vowel:
-        log.error("No vowel key in the stroke")
-        return None
-
-    if has_star:
-        # Place the star. It goes between 'O' and 'E' in steno order. This is
-        # a bit easier since we're requiring a vowel key in each stroke.
-        pos = stroke.find("O") + 1
-
-        if pos == 0:
-            pos = stroke.find("A") + 1
-
-        if pos == 0:
-            pos = stroke.find("E")
-
-        if pos == -1:
-            pos = stroke.find("U")
-
-        if pos == -1:
-            log.error("All generated strokes must have a vowel key")
-            return None
-
-        # Add the star.
-        stroke = stroke[:pos] + "*" + stroke[pos:]
-
-    return stroke
-
-
-def build_stroke_helper(components):
-    """Create a steno stroke from a list of components of the stroke.
-
-    Example:
-        components = ["PB", "OE", "*T"]
-        returns ("PBOET", True)
-
-    If any component has a "*" in any position, then the returned stroke will
-    have a "*" in the correct position, otherwise it will not have a star.
-
-    Note: This function requires that one of the components has at least one
-    vowels character (A, O, E, or U).
-
-    Args:
-        Components: A list of steno stroke components. Each element of the list
-            is a string specifying keys to add to the stroke, and any element
-            may contain a "*" anywhere to indicate that a "*" should be added
-            to the correct position in the stroke.
-
-    Returns:
-        A tuple where the first element is the concatenation of `components`
-        but with the "*" (if any) removed, and the second element is True if
-        some componenet had a "*" anywhere.
-        If concatenating `components` would give a stroke that is out of steno
-        order, then None is returned instead.
-    """
-    stroke = ""
-    has_star = False
-    order_pos = 0
-
-    for keys_for_phoneme in components:
-        for letter in keys_for_phoneme:
-            if letter == "*":
-                has_star = True
-                continue
-            if len(stroke) > 0 and letter == stroke[-1]:
-                # We're repeating a letter; this is valid, just don't double
-                # the letter in the returned steno stroke.
-                continue
-
-            order_pos = config.STENO_ORDER.find(letter, order_pos)
-            if order_pos == -1:
-                if letter in config.STENO_ORDER:
-                    # The letter is out of steno order.
-                    return None
-
-                log = logging.getLogger("dictionary_generator")
-                log.error("Invalid symbol `%s` in steno stroke", letter)
-                return None
-
-            # This letter is a valid addition to the stroke.
-            stroke += letter
-
-    return (stroke, has_star)
+import steno
 
 
 def get_stroke_components(phonemes, phonemes_to_steno):
@@ -160,22 +32,21 @@ def get_stroke_components(phonemes, phonemes_to_steno):
     ways_to_stroke = [[]]
 
     for phoneme in phonemes:
-        steno = phonemes_to_steno[phoneme]
-        if steno is None:
+        ways_to_write_phoneme = phonemes_to_steno[phoneme]
+        if ways_to_write_phoneme is None:
             log.error("No mapping given for phoneme `%s` in `%s`", phoneme, phonemes)
-        elif steno == config.NO_STENO_MAPPING:
+        elif ways_to_write_phoneme == config.NO_STENO_MAPPING:
             log.error("No steno mapping for phoneme `%s` in `%s`", phoneme, phonemes)
             return None
-        elif isinstance(steno, list):
-            new_ways_to_stroke = []
-            for keys in steno:
-                for partial_stroke in ways_to_stroke:
-                    new_ways_to_stroke.append(partial_stroke + [keys])
 
-            ways_to_stroke = new_ways_to_stroke
-        else:
-            for prev_strokes in ways_to_stroke:
-                prev_strokes += [steno]
+        new_ways_to_stroke = []
+        for keys in ways_to_write_phoneme:
+            # Append the `keys` list to each list of how to stroke the previous
+            # components.
+            for partial_stroke in ways_to_stroke:
+                new_ways_to_stroke.append(partial_stroke + keys)
+
+        ways_to_stroke = new_ways_to_stroke
 
     return ways_to_stroke
 
@@ -187,11 +58,12 @@ def syllables_to_steno(syllables):
         syllables: A list of Syllables (see syllable.py)
 
     Returns:
-        A list of strings. Each string is way to write `syllables` in steno
-        given the rules for syllable splitting, postprocessing, and phoneme to
-        steno key conversion in config.py.
+        A list of StrokeSequences. Each stroke sequence is a way to steno the
+        word for the input syllables given the rules for syllable splitting,
+        postprocessing, and phoneme to steno key conversion.
     """
 
+    log = logging.getLogger("dictionary_generator")
     translations = []  # List of all ways to stroke the syllable sequence.
 
     for syllable in syllables:
@@ -228,34 +100,39 @@ def syllables_to_steno(syllables):
         ways_to_stroke_syllable = temp.copy()
 
         potential_strokes = []
-        for stroke_components in ways_to_stroke_syllable:
-            stroke = build_stroke_from_components(stroke_components)
-
-            if stroke is not None:
+        for keys_list in ways_to_stroke_syllable:
+            try:
+                stroke = steno.Stroke(keys_list)
+            except steno.OutOfStenoOrderError:
+                log.debug("Out of steno order `%s`", keys_list)
+            else:
                 potential_strokes.append(stroke)
 
         if len(potential_strokes) == 0:
-            log = logging.getLogger("dictionary_generator")
             log.info("No valid way to stroke the syllable `%s`", syllable)
             return None
 
         if len(translations) == 0:
-            translations = potential_strokes
+            # translations = potential_strokes
+            for stroke in potential_strokes:
+                translations.append(steno.StrokeSequence([stroke]))
         else:
             new_translations = []
-            for prev_strokes in translations:
+            for stroke_sequence in translations:
                 for stroke in potential_strokes:
-                    new_translations.append(prev_strokes + "/" + stroke)
+                    new_sequence = copy.deepcopy(stroke_sequence)
+                    new_sequence.append_stroke(stroke)
+                    new_translations.append(new_sequence)
 
             translations = new_translations.copy()
 
     # Run custom postprocessing.
     new_translations = []
-    for steno in translations:
-        new_steno = config.postprocess_steno_sequence(steno, syllables)
+    for stroke_sequence in translations:
+        new_stroke_sequence = config.postprocess_steno_sequence(stroke_sequence, syllables)
 
-        if new_steno is not None:
-            new_translations.append(new_steno)
+        if new_stroke_sequence is not None:
+            new_translations.append(new_stroke_sequence)
 
     translations = new_translations
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+PyYAML==6.0
+schema==0.7.5


### PR DESCRIPTION
Now for the vast majority of cases, users will only need to update a YAML config file to customize how their dictionary is generated, instead of having to change a Python file.

Additionally, the YAML file sets up the configuration so that it should be straightforward to update the vowels and consonants mappings, update phonology rules, and create many useful custom postprocessing rules.