### PR TITLE
Enable recursively combining JSON dictionaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ You may want to split your steno dictionaries into different files for better or
 1. In a terminal, run `cd /path/to/your/dictionaries`
 2. Run `python /path/to/steno-tools/combine_dictionaries.py <directory>` where `<directory>` is the name of the folder containing the dictionaries you want to combine.
 
+By default, only JSON files directly in the specified directory will be merged, but you can recursively search all directories with the `--recursive` flag. If multiple files have an entry for the same stroke sequence, the first entry will have priority and later entries will be ignored. Files are searched alphabetically but filename portions with numbers are sorted by the numbers; so if you have three files `priority-1-prefixes.json`, `priority-5-names.json`, and `priority-20-other.json`, they will be searched in that order, NOT as `priority-1-prefixes.json`, `priority-20-other.json`, `priority-5-names.json`. Use the flag `-v` or `-vv` to get more information on which files are searched when for your specific directory structure.
+
 For more usage information, run `python /path/to/steno-tools/combine_dictionaries.py -h`.
 
 ## Sort Words By Frequency

--- a/combine_dictionaries.py
+++ b/combine_dictionaries.py
@@ -2,20 +2,69 @@
 
 import argparse
 import json
+import logging
 import os
-import sys
+import re
 
 
-def combine_json_files_directory(directory, force_overwrite=False):
+def natural_sort_key(string):
+    """Break a string into a list of substrings and numbers.
+
+    This is intended to be used as a sorting key.
+
+    Example input: "123hello-word.45.txt"
+            output: [123, "hello-world.", 45, ".txt"]
+
+    Returns:
+        A list of strings and non-negative integers. Each digit in the input
+        string is converted to a number; converting each element of the list
+        to a string and joining them all gives the input value.
+    """
+
+    return [int(substr) if substr.isdigit() else substr for substr in re.split("([0-9]+)", string)]
+
+
+def get_sorted_json_files(directory, recursive):
+    """Returns a list of JSON files sorted by directory and by natural_sort_key.
+
+    Args:
+        directory: The directory to search for JSON files.
+        recursive: True if the given directory should be searched recursively.
+            If False, only JSON files directly inside the specified directory
+            will be returned.
+
+    Returns:
+        A list of JSON filenames with the paths starting with the path of the
+        `directory` input.
+    """
+
+    json_files = []
+
+    for item in sorted(os.listdir(directory), key=natural_sort_key):
+        path = os.path.join(directory, item)
+
+        if os.path.isfile(path):
+            if path.endswith(".json"):
+                json_files.append(path)
+        elif recursive:
+            json_files += get_sorted_json_files(path, recursive)
+
+    return json_files
+
+
+def combine_json_files_directory(directory, recursive, force_overwrite, log):
     """Combine all JSON files in a directory into a single JSON file.
 
     The created file is named <directory>.json.
 
     Args:
         directory: The name of a directory.
+        recursive: Whether subdirectories should be recursively searched for
+            JSON files which would be added to the final JSON file.
         force_overwrite: True if the output file should be written even if it
             already exists. If the file doesn't already exist, this parameter
             doesn't do anything.
+        log: A logger to write logs
 
     Raises:
         ValueError: If the input argument is not a directory.
@@ -24,31 +73,33 @@ def combine_json_files_directory(directory, force_overwrite=False):
         None
     """
 
+    # Ensure the directory exists.
     if not os.path.isdir(directory):
-        raise ValueError(f"`{directory}` is not a directory")
-
-    json_files = [
-        os.path.join(directory, file) for file in os.listdir(directory) if file.endswith(".json")
-    ]
-
-    if not json_files:
-        print(f"No JSON files found in directory `{directory}`", file=sys.stderr)
+        log.critical("`%s` is not a directory", directory)
+        return
 
     # Check if the output file already exists.
     new_filename = os.path.basename(directory) + ".json"
 
     if not force_overwrite and os.path.exists(new_filename):
         # If the file exists, prompt the user before overwriting it
-        response = input(
-            f"The file {new_filename} already exists. Do you want to overwrite it? (y/n) "
-        )
+        response = input(f"Do you want to overwrite the existing {new_filename} file? (y/n) ")
         if response.lower() != "y":
-            print(f"{new_filename} not overwritten.")
+            print(f"`{new_filename}` not overwritten")
             return
+
+    # Get all JSON files.
+    json_files = get_sorted_json_files(directory, recursive)
+
+    if not json_files:
+        log.warning("No JSON files found in directory `%s`", directory)
+        return
 
     # Combine contents of JSON files.
     combined_json = {}
     for file in json_files:
+        log.info("Merging `%s`", file)
+
         with open(file, "r", encoding="UTF-8") as file:
             file_contents = json.load(file)
             combined_json.update(file_contents)
@@ -65,13 +116,26 @@ def main():
     parser = argparse.ArgumentParser(
         description="Combine all JSON files in a directory into a single JSON file."
     )
-    parser.add_argument("directory", help="The directory containing JSON files to be combined.")
+    parser.add_argument("directory", help="the directory containing JSON files to be combined")
     parser.add_argument(
         "-f", "--force", action="store_true", help="force overwriting the output file"
     )
+    parser.add_argument(
+        "-r", "--recursive", action="store_true", help="combine subdirectories recursively"
+    )
+    parser.add_argument("-v", "--verbose", action="store_true", help="increase output verbosity")
     args = parser.parse_args()
 
-    combine_json_files_directory(args.directory, force_overwrite=args.force)
+    # Setup logging.
+    log_level = logging.WARNING
+    if args.verbose >= 1:
+        log_level = logging.INFO
+
+    log_format = "%(levelname)s: %(message)s"
+    logging.basicConfig(level=log_level, format=log_format)
+    log = logging.getLogger("combine_dictionaries")
+
+    combine_json_files_directory(args.directory, args.recursive, args.force, log)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This adds a `--recursive` flag to `combine_dictionaries.py` so that all subfolders of the specified directory are recursively searched for JSON files.

It also enforces a priority structure so that if a stroke sequence is defined multiple times across one or more files, only the highest-priority definition takes effect. Within a file, entries closer to the top have higher priority. Across files, files that are searched first have higher priority. Files are searched alphabetically, but portions of filenames that have numbers are compared as those numbers (this is called a natural sort). So the files `1-foo.json`, `3-foo.json`, `20-foo.json` will be searched in that order, NOT as `1-foo.json`, `20-foo.json`, `3-foo.json`. And if there's a subdirectory named `8-foo` it would be searched after `3-foo.json` and before `20-foo.json`, so all files (recursively) within `8-foo` would be searched after `3-foo.json` and before `20-foo.json`