### PR TITLE
Enable custom phoneme sequence mapping overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Stenography is a fascinating and efficient way of writing, used by court reporte
   - [Default Theory](#default-theory)
   - [Customizing the Default Theory](#customizing-the-generated-theory)
     - [Customizing Phonemes](#customizing-phonemes)
+    - [Overriding Phoneme Sequence Mappings](#overriding-phoneme-sequence-mappings)
     - [Postprocessing Strokes](#postprocessing-strokes)
 - [Combine Dictionaries](#combine-dictionaries)
   - [Usage](#usage-1)
@@ -81,6 +82,20 @@ If you change the list of phonemes in `consonants`, you'll need to update the `p
 3. If there are any additional consonants before the vowel that could not be prepended to the onset, append those consonants to the previous syllable, forming the previous syllable's coda.
 
 So your updates in the `phonology` specify how step 2 is done.
+
+#### Overriding Phoneme Sequence Mappings
+
+By default, the stroke for a syllable is constructed by mapping each phoneme to a set of keys and appending those keys to the stroke while ensuring that the stroke remains in steno order. However, in some cases you may want to override this behavior so that certain phoneme sequences are mapped all at once to a custom set of steno keys. This is done in the `phoneme_sequence_overrides` section of the YAML config file by adding a list of overrides. For example, if you want to map the right-side phoneme sequence `mp` to `*PL`, you would add the following to your config file.
+```
+phoneme_sequence_overrides:
+  - sequence:
+    - ["m", RIGHT_CONSONANT]
+    - ["p", RIGHT_CONSONANT]
+    keys: ["*PL"]
+```
+For each phoneme in the sequence, you must specify it as a `LEFT_CONSONANT`, `VOWEL`, or `RIGHT_CONSONANT`.
+
+Notably, these overrides only apply after words are split into syllables. This means that a word like `compost` will continue to be split into the syllables `com` and `post` (so this override will not apply to that word becuase the `m` and `p` are on different syllables), but the override will apply to the word `lamp`.
 
 #### Postprocessing Strokes
 

--- a/generator/configs/config.yaml
+++ b/generator/configs/config.yaml
@@ -132,6 +132,16 @@ consonants:
     keys_left: ["SKWR-"]
     keys_right: ["-PBLG"]
 
+# Add any overrides for how a sequence of phonemes should be mapped to steno
+# keys. The elements of each rule are:
+#   sequence: A list of lists. Each inner list must have exactly two elements
+#       with the first being the phoneme in IPA and the second element being
+#       either LEFT_CONSONANT, VOWEL, or RIGHT_CONSONANT to specify that this
+#       rule only applies when the phoneme is in that position of the syllable.
+#   keys: A list of strokes with each stroke being a valid way to map the
+#       specified phoneme sequence to steno keys. If there is more than one
+#       item in the list, then redundant translations will be made so that the
+#       phoneme sequence can be stroked with any of the indicated key clusters.
 phoneme_sequence_overrides:
   - sequence: # Ex: lURCH, resEARCH
     - ["ɝ", VOWEL]

--- a/generator/configs/config.yaml
+++ b/generator/configs/config.yaml
@@ -52,12 +52,6 @@ vowels:
     keys: ["AOU"] # Note: this is the same as for just 'u'.
   - phoneme: "jə" # Sounds the same as 'ju' to me.
     keys: ["AOU"]
-  - phoneme: "ɝtʃ" # Ex: lURCH, resEARCH
-    keys: ["UFRPB"]
-  - phoneme: "ɑɹtʃ" # Ex: ARCH, mARCH,
-    keys: ["AFRPB"]
-  - phoneme: "ɔɹtʃ" # Ex: tORCH, pORCH
-    keys: ["OFRPB"]
 
 # Consonant phonemes that may appear in the IPA pronunciation of words that
 # you want to generate steno strokes for. If you don't want to add a way to make
@@ -137,20 +131,36 @@ consonants:
   - phoneme: "dʒ" # Ex: JuDGe, friDGe, Germ
     keys_left: ["SKWR-"]
     keys_right: ["-PBLG"]
-  ############ Consonant Clusters ############
-  - phoneme: "st" # Ex: firST heiST, burST
-    keys_left: ["ST-"]
-    keys_right: ["-FT", "*S"]
-  - phoneme: "ŋk" # Ex: baNK, thaNKs
-    keys_left: NO_STENO_MAPPING
-    keys_right: ["-PBG"]  # Note: this colides with '-ŋ'
-  - phoneme: "mp" # Ex: raMP, cluMP
-    keys_left: NO_STENO_MAPPING
-    keys_right: ["*PL"]
-  - phoneme: "ntʃ" # Ex: lauNCH, braNCH
-    keys_left: NO_STENO_MAPPING
-    keys_right: ["-FRPB"]
 
+phoneme_sequence_overrides:
+  - sequence: # Ex: lURCH, resEARCH
+    - ["ɝ", VOWEL]
+    - ["tʃ", RIGHT_CONSONANT]
+    keys: ["UFRPB"]
+  - sequence: # Ex: ARCH, mARCH
+    - ["ɑɹ", VOWEL]
+    - ["tʃ", RIGHT_CONSONANT]
+    keys: ["AFRPB"]
+  - sequence: # Ex: tORCH, pORCH
+    - ["ɔɹ", VOWEL]
+    - ["tʃ", RIGHT_CONSONANT]
+    keys: ["OFRPB"]
+  - sequence: # Ex: firST heiST, burST
+    - ["s", RIGHT_CONSONANT]
+    - ["t", RIGHT_CONSONANT]
+    keys: ["-FT", "*S"]
+  - sequence: # Ex: baNK, thaNKs
+    - ["ŋ", RIGHT_CONSONANT]
+    - ["k", RIGHT_CONSONANT]
+    keys: ["-PBG"]  # Note: this collides with '-ŋ'
+  - sequence: # Ex: raMP, cluMP
+    - ["m", RIGHT_CONSONANT]
+    - ["p", RIGHT_CONSONANT]
+    keys: ["*PL"]
+  - sequence: # Ex: lauNCH, braNCH
+    - ["n", RIGHT_CONSONANT]
+    - ["tʃ", RIGHT_CONSONANT]
+    keys: ["-FRPB"]
 
 ############################# Phonology #############################
 
@@ -160,14 +170,12 @@ phonology:
   # Add your custom allowed rules to the below block.
   - allowed:
       # These sounds can come immediately before a vowel.
-      immediately_before_vowel: ["st"]
+      immediately_before_vowel: []
 
       # If the previous sound is an element of `prev` and the next sound is an
       # element of the corresponding `next` array, then `prev + next` is a
       # valid consonant cluster before a vowel.
-      previous_and_next_sounds:
-        - prev: ["st"]
-          next: ["j", "w", "ɹ"]
+      previous_and_next_sounds: []
 
   # The below rules are from https://en.wikipedia.org/wiki/English_phonology
   # You probably shouldn't change this unless:

--- a/generator/configs/config.yaml
+++ b/generator/configs/config.yaml
@@ -145,6 +145,18 @@ phoneme_sequence_overrides:
     - ["ɔɹ", VOWEL]
     - ["tʃ", RIGHT_CONSONANT]
     keys: ["OFRPB"]
+  - sequence: # Ex: sERVe, cURVe
+    - ["ɝ", VOWEL]
+    - ["v", RIGHT_CONSONANT]
+    keys: ["UFRB"]
+  - sequence: # Ex: thERE'VE
+    - ["ɛɹ", VOWEL]
+    - ["v", RIGHT_CONSONANT]
+    keys: ["AEUFRB"]
+  - sequence: # Ex: cARVe, stARVe
+    - ["ɑɹ", VOWEL]
+    - ["v", RIGHT_CONSONANT]
+    keys: ["AFRB"]
   - sequence: # Ex: firST heiST, burST
     - ["s", RIGHT_CONSONANT]
     - ["t", RIGHT_CONSONANT]

--- a/generator/ipa_utils.py
+++ b/generator/ipa_utils.py
@@ -1,5 +1,6 @@
 """Read IPA pronunciations for words and split IPA words into syllables."""
 
+import dataclasses
 import logging
 import random
 import re
@@ -135,6 +136,14 @@ def split_ipa_into_syllables(ipa, config):
     for vowel in vowels:
         ipa_copy = ipa_copy.replace(vowel, phoneme_to_marker[vowel])
 
+    @dataclasses.dataclass
+    class SyllablePhonemes:
+        """A struct used internally to strore phonemes for a syllable."""
+
+        onset: list[str]
+        nucleus: str
+        coda: list[str]
+
     syllables = []
     syllable_start_index = 0
     matches = re.finditer(r"\([0-9]+\)", ipa_copy)
@@ -144,7 +153,7 @@ def split_ipa_into_syllables(ipa, config):
         marker = ipa_copy[match.start() : match.end()]
         nucleus = marker_to_phoneme[marker]
         coda = []
-        syllables.append(Syllable(onset, nucleus, coda))
+        syllables.append(SyllablePhonemes(onset, nucleus, coda))
         syllable_start_index = match.end()
 
     if len(syllables) == 0:
@@ -200,4 +209,4 @@ def split_ipa_into_syllables(ipa, config):
 
         syllables[i].onset = new_onset
 
-    return syllables
+    return [Syllable(syll.onset, syll.nucleus, syll.coda) for syll in syllables]

--- a/generator/postprocessing.py
+++ b/generator/postprocessing.py
@@ -46,8 +46,8 @@ def _disallow_f_for_final_s_sound(strokes, syllables_ipa):
             Syllable.
     """
 
-    for stroke, ipa in zip(strokes, syllables_ipa):
-        if stroke.get_last_key() == Key.RF and len(ipa.coda) > 0 and ipa.coda[-1] == "s":
+    for stroke, syllable in zip(strokes, syllables_ipa):
+        if stroke.get_last_key() == Key.RF and syllable.is_last_phoneme_s():
             # This is invalid.
             strokes.clear()
 

--- a/generator/stroke_builder.py
+++ b/generator/stroke_builder.py
@@ -1,57 +1,12 @@
 """Convert IPA syllables into steno strokes."""
 
 import copy
+import itertools
 import logging
+import more_itertools
 
-from config import NO_STENO_MAPPING
 import postprocessing
 import steno
-
-
-def get_stroke_components(phonemes, func_possible_strokes_for_phoneme):
-    """Convert phonemes into their corresponding steno keys.
-
-    Args:
-        phonemes: A list of phonemes to convert to steno keys. The list should
-            correspond to one steno stroke.
-        phonemes_to_steno: A dictionary mapping phonemes to possible ways to
-            write that phoneme with steno. If there is only one way to write
-            the phoneme, the value will be a string specifying the steno keys.
-            If there are multiple ways to write the phoneme, the value will be
-            a list of strings with each element specifying the steno keys to
-            write the phoneme in a different way. If there is no way to write
-            the phoneme, the value should be config.NO_STENO_MAPPING.
-
-    Returns:
-        A list of list of strings. Each element of the returnd list is a way to
-        write the provided phonemes. Each character of each string within the
-        an inner list is the name of a steno key; for example, "K", "O", or "*".
-
-    """
-
-    log = logging.getLogger("dictionary_generator")
-    ways_to_stroke = [[]]
-
-    for phoneme in phonemes:
-        possible_strokes = func_possible_strokes_for_phoneme(phoneme)
-        log.debug("Possible strokes for `%s`: %s", phoneme, [str(s) for s in possible_strokes])
-        if possible_strokes is None:
-            log.error("No mapping given for phoneme `%s` in `%s`", phoneme, phonemes)
-        elif possible_strokes == NO_STENO_MAPPING:
-            log.error("No steno mapping for phoneme `%s` in `%s`", phoneme, phonemes)
-            return None
-
-        new_ways_to_stroke = []
-        for stroke in possible_strokes:
-            keys = stroke.get_keys()
-            # Append the `keys` list to each list of how to stroke the previous
-            # components.
-            for partial_stroke in ways_to_stroke:
-                new_ways_to_stroke.append(partial_stroke + keys)
-
-        ways_to_stroke = new_ways_to_stroke
-
-    return ways_to_stroke
 
 
 def syllables_to_steno(syllables, config):
@@ -68,70 +23,40 @@ def syllables_to_steno(syllables, config):
 
     log = logging.getLogger("dictionary_generator")
     translations = []  # List of all ways to stroke the syllable sequence.
+    phoneme_tuples_to_possible_key_clusters = config.get_phoneme_tuples_to_possible_key_clusters()
+
+    possible_strokes_for_each_syllable = []
 
     for syllable in syllables:
-        ways_to_stroke_onset = get_stroke_components(
-            syllable.onset, config.possible_strokes_for_left_consonant
-        )
-        ways_to_stroke_nucleus = get_stroke_components(
-            [syllable.nucleus], config.possible_strokes_for_vowel
-        )
-        ways_to_stroke_coda = get_stroke_components(
-            syllable.coda, config.possible_strokes_for_right_consonant
+        possible_keys_for_each_phoneme_cluster = syllable.map_atoms(
+            phoneme_tuples_to_possible_key_clusters
         )
 
-        if (
-            ways_to_stroke_onset is None
-            or ways_to_stroke_nucleus is None
-            or ways_to_stroke_coda is None
-        ):
-            # There's no way to stroke this syllable.
-            return None
+        possible_keys_for_syllable = itertools.product(*possible_keys_for_each_phoneme_cluster)
+        possible_keys_for_syllable = [
+            list(more_itertools.flatten(tpl)) for tpl in possible_keys_for_syllable
+        ]
 
-        # Combine the parts of the stroke.
-        # First add the onset parts of the stroke.
-        ways_to_stroke_syllable = ways_to_stroke_onset.copy()
-
-        # Next add the nucleus of the stroke.
-        temp = []
-        for partial_stroke in ways_to_stroke_syllable:
-            for nucleus_part in ways_to_stroke_nucleus:
-                temp.append(partial_stroke + nucleus_part)
-        ways_to_stroke_syllable = temp.copy()
-
-        # Finally add the coda of the stroke.
-        temp.clear()
-        for partial_stroke in ways_to_stroke_syllable:
-            for coda_part in ways_to_stroke_coda:
-                temp.append(partial_stroke + coda_part)
-        ways_to_stroke_syllable = temp.copy()
-
-        potential_strokes = []
-        for keys_list in ways_to_stroke_syllable:
+        possible_strokes_for_syllable = []
+        for keys in possible_keys_for_syllable:
             try:
-                stroke = steno.Stroke(keys_list)
+                stroke = steno.Stroke(keys)
             except steno.OutOfStenoOrderError:
-                log.debug("Out of steno order `%s`", keys_list)
+                log.debug("Out of steno order `%s`", keys)
             else:
-                potential_strokes.append(stroke)
+                possible_strokes_for_syllable.append(stroke)
 
-        if len(potential_strokes) == 0:
+        if len(possible_strokes_for_syllable) == 0:
             log.info("No valid way to stroke the syllable `%s`", syllable)
             return None
 
-        if len(translations) == 0:
-            # translations = potential_strokes
-            for stroke in potential_strokes:
-                translations.append(steno.StrokeSequence([stroke]))
-        else:
-            new_translations = []
-            for stroke_sequence in translations:
-                for stroke in potential_strokes:
-                    new_sequence = copy.deepcopy(stroke_sequence)
-                    new_sequence.append_stroke(stroke)
-                    new_translations.append(new_sequence)
+        possible_strokes_for_each_syllable.append(possible_strokes_for_syllable)
 
-            translations = new_translations.copy()
+    possible_strokes = itertools.product(*possible_strokes_for_each_syllable)
+    translations = [
+        steno.StrokeSequence(copy.deepcopy(list(strokes_tuple)))
+        for strokes_tuple in possible_strokes
+    ]
 
     # Run custom postprocessing.
     new_translations = []

--- a/generator/syllable.py
+++ b/generator/syllable.py
@@ -1,32 +1,98 @@
 """A syllable written with IPA symbols."""
 
+import enum
+from typing import NamedTuple
+
+
+class SyllableRegion(enum.Enum):
+    """A region of a syllable."""
+
+    ONSET = enum.auto()
+    NUCLEUS = enum.auto()
+    CODA = enum.auto()
+
+
+class SyllableAtom(NamedTuple):
+    """The smallest block of a syllable."""
+
+    phoneme: str
+    region: SyllableRegion
+
 
 class Syllable:
-    """A syllable written with IPA symbols.
+    """A collection of SyllableAtoms constituting a single syllable.
 
     Attributes:
-        onset:
-            A list of strings. Each string is a consonant phoneme in IPA.
-            Together, the elements of the list make the syllable's onset (the
-            consonant sounds before the vowel).
-        nucleus:
-            A string that is the syllable's vowel sound written in IPA.
-        coda:
-            A list of strings. Each string is a consonant phoneme in IPA.
-            Together, the elements of the list make the syllable's coda (the
-            consonant sounds after the vowel).
+        atoms: A list of SyllableAtoms. Concatenating the atoms and reading the
+            phonemes from each atom gives the pronunciation of the syllable.
     """
 
     def __init__(self, onset, nucleus, coda):
-        self.onset = onset
-        self.nucleus = nucleus
-        self.coda = coda
+        """Creates a Syllable.
 
-    def str_debug(self):
-        """Return a string of the syllable for debugging purposes."""
-        return str(self.onset) + str(self.nucleus) + str(self.coda)
+        Args:
+            onset: A list of strings. Each string is a phoneme in the onset.
+            nucleus: A string specifying the IPA symbols for the nucleus.
+            coda: A list of strings. Each string is a phoneme in the coda.
+        """
+
+        self._atoms = []
+
+        for phoneme in onset:
+            self._atoms.append(SyllableAtom(phoneme, SyllableRegion.ONSET))
+
+        self._atoms.append(SyllableAtom(nucleus, SyllableRegion.NUCLEUS))
+
+        for phoneme in coda:
+            self._atoms.append(SyllableAtom(phoneme, SyllableRegion.CODA))
 
     def __str__(self):
-        onset = "".join(self.onset)
-        coda = "".join(self.coda)
-        return f"{onset + self.nucleus + coda}"
+        return "".join([phoneme for phoneme, _ in self._atoms])
+
+    def map_atoms(self, atom_tuples_to_obj):
+        """Map the phonemes of this syllable to objects.
+
+        Args:
+            atom_tuples_to_obj: A dictionary where the keys are tuples of
+                SyllableAtoms. There's no guarantee on what the values are.
+
+        Returns:
+            A list containing only elements which are values from the input
+            dictionary. The list is formed by iterating this syllable's
+            SyllableAtoms and at each step checking for the longest key in
+            `atom_tuples_to_obj` that matches the next `n` elements (where `n`
+            is the length of that specific key); those SyllableAtoms are then
+            mapped to the corresponding value in `atom_tuples_to_obj`.
+        """
+        objs = []
+        max_tuple_length = len(max(atom_tuples_to_obj, key=len))
+
+        start = 0
+        while start < len(self._atoms):
+            found_match = False
+
+            for length in range(max_tuple_length + 1, 0, -1):
+                end = start + length
+                if end > len(self._atoms):
+                    continue
+
+                obj = atom_tuples_to_obj.get(tuple(self._atoms[start:end]), None)
+
+                if obj is not None:
+                    objs.append(obj)
+                    start += length
+                    found_match = True
+                    break  # Break out of the inner loop
+
+            if not found_match:
+                print(f"No match for {self._atoms[start]}")
+                return None
+
+        return objs
+
+    def is_last_phoneme_s(self):
+        """Return True if the last phoneme of this syllable is 's'."""
+        if len(self._atoms) == 0:
+            return False
+
+        return self._atoms[-1].phoneme == "s"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+more_itertools==9.1.0
 PyYAML==6.0
 schema==0.7.5


### PR DESCRIPTION
This adds a new feature so that in the config.yaml you can specify that when certain phonemes appear together in a syllable, their conversion to steno keys should be the specified keys rather than the default behavior of combining the keys mapped to each phoneme. One way this can be useful is to avoid out-of-steno-order errors; for example, if the phonemes `n` and `tʃ` are mapped on the right-side to -PB and -FP, then the phoneme cluster `ntʃ` would by default be `-PBF` which is out of steno order, so the generator will not be able to make translations for words like `lunch`; but with the new overrides feature you can specify that when right-side `n` is followed by right-side `tʃ` it should get translated to a custom key cluster (e.g., `-FRPB`).