### PR TITLE
Add unit tests for syllable.py and steno.py

### DIFF
--- a/.github/workflows/python-styling.yml
+++ b/.github/workflows/python-styling.yml
@@ -27,7 +27,8 @@ jobs:
         min_allowed_lint_score_per_file=9.0
         
         echo "Min allowed score per file is $min_allowed_lint_score_per_file"
-        for file in $(git ls-files '*.py')
+        # Ignore test files.
+        for file in $(git ls-files '*.py' ':!:tests/')
         do
           echo "Linting $file"
           pylint "$file" --fail-under $min_allowed_lint_score_per_file

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,29 @@
+name: Python Testing
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  pytest:
+    name: Python Testing
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+      - name: Run tests
+        run: |
+          cd generator
+          python -m pytest ../tests/generator
+

--- a/generator/ipa_utils.py
+++ b/generator/ipa_utils.py
@@ -77,6 +77,9 @@ def get_ipa_symbols(word_to_ipa):
         A Set of the IPA symbols used in `word_to_ipa`
     """
 
+    if len(word_to_ipa) == 0:
+        return set()
+
     # Check the IPA symbols used in a bunch of random words.
     num_words_to_check = 10000
 
@@ -111,6 +114,7 @@ def split_ipa_into_syllables(ipa, config):
 
     Args:
         ipa: A string representing the pronunciation for some word in IPA.
+        config: The Config specifying how to map IPA to strokes.
 
     Returns:
         A list of Syllables (see syllable.py) for the word.

--- a/generator/syllable.py
+++ b/generator/syllable.py
@@ -41,7 +41,8 @@ class Syllable:
         for phoneme in onset:
             self._atoms.append(SyllableAtom(phoneme, SyllableRegion.ONSET))
 
-        self._atoms.append(SyllableAtom(nucleus, SyllableRegion.NUCLEUS))
+        if nucleus != "":
+            self._atoms.append(SyllableAtom(nucleus, SyllableRegion.NUCLEUS))
 
         for phoneme in coda:
             self._atoms.append(SyllableAtom(phoneme, SyllableRegion.CODA))

--- a/tests/generator/test_steno.py
+++ b/tests/generator/test_steno.py
@@ -1,0 +1,805 @@
+import copy
+import pytest
+
+from steno import Key, Stroke, StrokeSequence
+from steno import MissingDashInStrokeError, OutOfStenoOrderError
+
+
+#####################################################################
+# Test Stroke class
+#####################################################################
+
+
+class TestStroke:
+    #################################################################
+    # Test __init__()
+    #################################################################
+
+    def test_init_empty(self):
+        stroke = Stroke()
+
+        assert stroke.get_keys() == []
+
+    def test_init_empty_list(self):
+        stroke = Stroke([])
+
+        assert stroke.get_keys() == []
+
+    def test_init_only_star(self):
+        keys = [Key.STAR]
+        stroke = Stroke(keys)
+
+        assert stroke.get_keys() == keys
+
+    def test_init_only_num(self):
+        keys = [Key.NUM]
+        stroke = Stroke(keys)
+
+        assert stroke.get_keys() == keys
+
+    def test_init_multiple_keys(self):
+        keys = [Key.LS, Key.LW, Key.A, Key.STAR, Key.RL]
+        stroke = Stroke(keys)
+
+        assert stroke.get_keys() == keys
+
+    def test_init_star_out_of_order(self):
+        keys = [Key.LS, Key.STAR, Key.LW, Key.A, Key.RL]
+        stroke = Stroke(keys)
+
+        assert stroke.get_keys() == [Key.LS, Key.LW, Key.A, Key.STAR, Key.RL]
+
+    def test_init_keys_out_of_order(self):
+        with pytest.raises(OutOfStenoOrderError):
+            Stroke([Key.A, Key.LW])
+
+    #################################################################
+    # Test __eq__()
+    #################################################################
+
+    def test_stroke_equality_when_equal(self):
+        keys = [Key.A, Key.RT]
+        stroke1 = Stroke(keys)
+        stroke2 = Stroke(keys)
+        assert stroke1 == stroke2
+
+    def test_stroke_equality_when_not_equal(self):
+        keys1 = [Key.A, Key.RT]
+        keys2 = [Key.A, Key.RD]
+        stroke1 = Stroke(keys1)
+        stroke2 = Stroke(keys2)
+        assert stroke1 != stroke2
+
+    def test_stroke_equality_when_different_key_combination(self):
+        keys1 = [Key.A, Key.RT]
+        keys2 = [Key.A, Key.RT, Key.RD]
+        stroke1 = Stroke(keys1)
+        stroke2 = Stroke(keys2)
+        assert stroke1 != stroke2
+
+    def test_stroke_equality_when_one_is_starred(self):
+        keys1 = [Key.A, Key.RT]
+        keys2 = [Key.A, Key.STAR, Key.RT]
+        stroke1 = Stroke(keys1)
+        stroke2 = Stroke(keys2)
+        assert stroke1 != stroke2
+
+    def test_stroke_equality_when_one_is_none(self):
+        stroke1 = Stroke([Key.A, Key.RT])
+        stroke2 = None
+        assert stroke1 != stroke2
+
+    def test_stroke_equality_when_both_are_none(self):
+        stroke1 = None
+        stroke2 = None
+        assert stroke1 == stroke2
+
+    #################################################################
+    # Test __lt__()
+    #################################################################
+
+    def test_lt_operator_false_when_equal(self):
+        stroke1 = Stroke([Key.LK, Key.O, Key.RD])
+        stroke2 = Stroke([Key.LK, Key.O, Key.RD])
+
+        assert not (stroke1 < stroke2)
+        assert not (stroke2 < stroke1)
+        assert stroke1 == stroke2
+
+    def test_lt_operator_unstarred_is_less(self):
+        stroke1 = Stroke([Key.LK, Key.O, Key.RD])
+        stroke2 = Stroke([Key.LK, Key.O, Key.STAR, Key.RD])
+
+        assert stroke1 < stroke2
+        assert not (stroke2 < stroke1)
+
+    def test_lt_operator_star_is_tiebreaker(self):
+        stroke1 = Stroke([Key.LK, Key.RP])
+        stroke2 = Stroke([Key.LK, Key.STAR, Key.RP])
+        stroke3 = Stroke([Key.LK, Key.RG])
+        stroke4 = Stroke([Key.LK, Key.STAR, Key.RZ])
+
+        assert stroke1 < stroke2
+        assert not (stroke2 < stroke1)
+
+        assert stroke2 < stroke3
+        assert not (stroke3 < stroke2)
+
+        assert stroke3 < stroke4
+        assert not (stroke4 < stroke3)
+
+    def test_lt_operator_shorter_is_less(self):
+        stroke1 = Stroke([Key.LK, Key.O, Key.RD])
+        stroke2 = Stroke([Key.LK, Key.O, Key.RD, Key.RZ])
+
+        assert stroke1 < stroke2
+        assert not (stroke2 < stroke1)
+
+    def test_lt_operator_same_prefix(self):
+        stroke1 = Stroke([Key.LK, Key.O, Key.RF, Key.RR, Key.RB])
+        stroke2 = Stroke([Key.LK, Key.O, Key.RD])
+
+        assert stroke1 < stroke2
+        assert not (stroke2 < stroke1)
+
+    def test_lt_operator_different_start(self):
+        stroke1 = Stroke([Key.LK, Key.O, Key.RD])
+        stroke2 = Stroke([Key.LP, Key.A, Key.RT])
+
+        assert stroke1 < stroke2
+        assert not (stroke2 < stroke1)
+
+    #################################################################
+    # Test __str__()
+    #################################################################
+
+    def test_str_empty(self):
+        stroke = Stroke([])
+        assert str(stroke) == "-"
+
+    def test_str_only_left_consonants(self):
+        stroke = Stroke([Key.LT, Key.LK])
+        assert str(stroke) == "TK-"
+
+    def test_str_only_left_consonants_and_star(self):
+        stroke = Stroke([Key.LT, Key.LK, Key.STAR])
+        assert str(stroke) == "TK*"
+
+    def test_str_only_right_consonants(self):
+        stroke = Stroke([Key.RP, Key.RL])
+        assert str(stroke) == "-PL"
+
+    def test_str_only_right_consonants_and_star(self):
+        stroke = Stroke([Key.STAR, Key.RP, Key.RL])
+        assert str(stroke) == "*PL"
+
+    def test_str_both_consonants(self):
+        stroke = Stroke([Key.LK, Key.RP, Key.RL])
+        assert str(stroke) == "K-PL"
+
+    def test_str_both_consonants_and_star(self):
+        stroke = Stroke([Key.LK, Key.STAR, Key.RP, Key.RL])
+        assert str(stroke) == "K*PL"
+
+    def test_str_has_vowel(self):
+        stroke = Stroke([Key.A, Key.O])
+        assert str(stroke) == "AO"
+
+    def test_str_only_star(self):
+        stroke = Stroke([Key.STAR])
+        assert str(stroke) == "*"
+
+    def test_str_has_vowels_and_star(self):
+        stroke = Stroke([Key.A, Key.O, Key.STAR, Key.U])
+        assert str(stroke) == "AO*U"
+
+    def test_str_complex_no_star(self):
+        stroke = Stroke([Key.LS, Key.LT, Key.O, Key.RP])
+        assert str(stroke) == "STOP"
+
+    def test_str_complex_with_star(self):
+        stroke = Stroke([Key.LS, Key.LT, Key.O, Key.STAR, Key.RP])
+        assert str(stroke) == "STO*P"
+
+    #################################################################
+    # Test from_string()
+    #################################################################
+
+    def test_from_string_empty(self):
+        with pytest.raises(MissingDashInStrokeError):
+            Stroke.from_string("")
+
+    def test_from_string_just_dash(self):
+        stroke = Stroke.from_string("-")
+        expected = Stroke([])
+
+        assert stroke == expected
+
+    def test_from_string_only_left_consonants(self):
+        stroke = Stroke.from_string("SR-")
+        expected = Stroke([Key.LS, Key.LR])
+
+        assert stroke == expected
+
+    def test_from_string_left_consonants_with_star(self):
+        stroke = Stroke.from_string("SR*")
+        expected = Stroke([Key.LS, Key.LR, Key.STAR])
+
+        assert stroke == expected
+
+    def test_from_string_only_right_consonants(self):
+        stroke = Stroke.from_string("-FB")
+        expected = Stroke([Key.RF, Key.RB])
+
+        assert stroke == expected
+
+    def test_from_string_right_consonants_with_star(self):
+        stroke = Stroke.from_string("*FB")
+        expected = Stroke([Key.RF, Key.RB, Key.STAR])
+
+        assert stroke == expected
+
+    def test_from_string_both_consonants(self):
+        stroke = Stroke.from_string("SR-FB")
+        expected = Stroke([Key.LS, Key.LR, Key.RF, Key.RB])
+
+        assert stroke == expected
+
+    def test_from_string_both_consonants_with_star(self):
+        stroke = Stroke.from_string("SR*FB")
+        expected = Stroke([Key.LS, Key.LR, Key.STAR, Key.RF, Key.RB])
+
+        assert stroke == expected
+
+    def test_from_string_only_vowels(self):
+        stroke = Stroke.from_string("AU")
+        expected = Stroke([Key.A, Key.U])
+
+        assert stroke == expected
+
+    def test_from_string_vowels_with_star(self):
+        stroke = Stroke.from_string("A*U")
+        expected = Stroke([Key.A, Key.STAR, Key.U])
+
+        assert stroke == expected
+
+    def test_from_string_all_regions(self):
+        stroke = Stroke.from_string("TPUPB")
+        expected = Stroke([Key.LT, Key.LP, Key.U, Key.RP, Key.RB])
+
+        assert stroke == expected
+
+    def test_from_string_all_regions_with_star(self):
+        stroke = Stroke.from_string("TP*UPB")
+        expected = Stroke([Key.LT, Key.LP, Key.STAR, Key.U, Key.RP, Key.RB])
+
+        assert stroke == expected
+
+    def test_from_string_out_of_steno_order(self):
+        with pytest.raises(OutOfStenoOrderError):
+            Stroke.from_string("HS-")
+
+    def test_from_string_star_out_of_steno_order(self):
+        with pytest.raises(OutOfStenoOrderError):
+            stroke = Stroke.from_string("K*W")
+            print(f"s: {str(s)}")
+
+    def test_from_string_missing_only_left_consonants_missing_dash(self):
+        with pytest.raises(MissingDashInStrokeError):
+            Stroke.from_string("WH")
+
+    def test_from_string_missing_only_right_consonants_missing_dash(self):
+        with pytest.raises(MissingDashInStrokeError):
+            Stroke.from_string("FG")
+
+    def test_from_string_missing_both_consonants_missing_dash(self):
+        with pytest.raises(MissingDashInStrokeError):
+            Stroke.from_string("WHFG")
+
+    #################################################################
+    # Test add_keys_maintain_steno_order()
+    #################################################################
+
+    def test_add_keys_maintain_order_empty_stroke(self):
+        stroke = Stroke()
+        keys = [Key.LS, Key.LT, Key.A]
+
+        stroke.add_keys_maintain_steno_order(keys)
+
+        assert stroke.get_keys() == keys
+
+    def test_add_keys_maintain_order_non_empty_stroke(self):
+        stroke = Stroke([Key.LS, Key.LT])
+        keys = [Key.A, Key.E]
+
+        stroke.add_keys_maintain_steno_order(keys)
+
+        assert stroke.get_keys() == [Key.LS, Key.LT, Key.A, Key.E]
+
+    def test_add_keys_maintain_order_added_keys_out_of_order(self):
+        stroke = Stroke([Key.LS, Key.LT])
+        keys = [Key.RG, Key.RR]
+
+        with pytest.raises(OutOfStenoOrderError):
+            stroke.add_keys_maintain_steno_order(keys)
+
+    def test_add_keys_maintain_order_appending_is_out_of_order(self):
+        stroke = Stroke([Key.LS, Key.A])
+        keys = [Key.LH, Key.RR]
+
+        with pytest.raises(OutOfStenoOrderError):
+            stroke.add_keys_maintain_steno_order(keys)
+
+    def test_add_keys_maintain_order_duplicate_key(self):
+        stroke = Stroke([Key.LS, Key.LT])
+        keys = [Key.LT, Key.A]
+
+        stroke.add_keys_maintain_steno_order(keys)
+
+        assert stroke.get_keys() == [Key.LS, Key.LT, Key.A]
+
+    def test_add_keys_maintain_order_star_anywhere(self):
+        stroke = Stroke([Key.LS, Key.LT, Key.RG])
+        keys = [Key.STAR]
+
+        stroke.add_keys_maintain_steno_order(keys)
+
+        assert stroke.get_keys() == [Key.LS, Key.LT, Key.STAR, Key.RG]
+
+    #################################################################
+    # Test add_keys_ignore_steno_order()
+    #################################################################
+
+    def test_add_keys_ignore_order_empty_stroke(self):
+        stroke = Stroke()
+        keys = [Key.LS, Key.LT, Key.A]
+
+        stroke.add_keys_ignore_steno_order(keys)
+
+        assert stroke.get_keys() == keys
+
+    def test_add_keys_ignore_order_non_empty_stroke(self):
+        stroke = Stroke([Key.LS, Key.LT])
+        keys = [Key.A, Key.E]
+
+        stroke.add_keys_ignore_steno_order(keys)
+
+        assert stroke.get_keys() == [Key.LS, Key.LT, Key.A, Key.E]
+
+    def test_add_keys_ignore_order_added_keys_out_of_order(self):
+        stroke = Stroke([Key.LS, Key.LT])
+        keys = [Key.RG, Key.RR]
+
+        stroke.add_keys_ignore_steno_order(keys)
+
+        assert stroke.get_keys() == [Key.LS, Key.LT, Key.RR, Key.RG]
+
+    def test_add_keys_ignore_order_appending_is_out_of_order(self):
+        stroke = Stroke([Key.LS, Key.A])
+        keys = [Key.LH, Key.RR]
+
+        stroke.add_keys_ignore_steno_order(keys)
+
+        assert stroke.get_keys() == [Key.LS, Key.LH, Key.A, Key.RR]
+
+    def test_add_keys_ignore_order_duplicate_key(self):
+        stroke = Stroke([Key.LS, Key.LT])
+        keys = [Key.LT, Key.A]
+
+        stroke.add_keys_ignore_steno_order(keys)
+
+        assert stroke.get_keys() == [Key.LS, Key.LT, Key.A]
+
+    def test_add_keys_ignore_order_star_anywhere(self):
+        stroke = Stroke([Key.LS, Key.LT, Key.RG])
+        keys = [Key.STAR]
+
+        stroke.add_keys_ignore_steno_order(keys)
+
+        assert stroke.get_keys() == [Key.LS, Key.LT, Key.STAR, Key.RG]
+
+    #################################################################
+    # Test clear_keys()
+    #################################################################
+
+    def test_clear_keys_empty_stroke(self):
+        stroke = Stroke()
+        keys = [Key.LS, Key.LT, Key.A]
+
+        stroke.clear_keys(keys)
+
+        assert stroke.get_keys() == []
+
+    def test_clear_keys_non_empty_stroke(self):
+        stroke = Stroke([Key.LS, Key.LT, Key.A])
+        keys = [Key.LT, Key.A]
+
+        stroke.clear_keys(keys)
+
+        assert stroke.get_keys() == [Key.LS]
+
+    def test_clear_keys_no_matching_keys(self):
+        stroke = Stroke([Key.LS, Key.LT, Key.A])
+        keys = [Key.RF, Key.RR]
+
+        stroke.clear_keys(keys)
+
+        assert stroke.get_keys() == [Key.LS, Key.LT, Key.A]
+
+    def test_clear_keys_star_key(self):
+        stroke = Stroke([Key.LS, Key.LT, Key.STAR])
+        keys = [Key.STAR]
+
+        stroke.clear_keys(keys)
+
+        assert stroke.get_keys() == [Key.LS, Key.LT]
+
+    #################################################################
+    # Test clear_vowels()
+    #################################################################
+
+    def test_clear_all_vowels_empty_stroke(self):
+        stroke = Stroke()
+        stroke.clear_all_vowels()
+
+        assert stroke.get_keys() == []
+
+    def test_clear_all_vowels_non_empty_stroke(self):
+        stroke = Stroke([Key.LS, Key.LT, Key.A, Key.E, Key.RP])
+        stroke.clear_all_vowels()
+
+        assert stroke.get_keys() == [Key.LS, Key.LT, Key.RP]
+
+    def test_clear_all_vowels_no_vowels(self):
+        stroke = Stroke([Key.LS, Key.LT, Key.STAR, Key.RP])
+        stroke.clear_all_vowels()
+
+        assert stroke.get_keys() == [Key.LS, Key.LT, Key.STAR, Key.RP]
+
+    #################################################################
+    # Test get_vowels()
+    #################################################################
+
+    def test_get_vowels_empty_stroke(self):
+        stroke = Stroke()
+
+        assert stroke.get_vowels() == []
+
+    def test_get_vowels_non_empty_stroke(self):
+        stroke = Stroke([Key.LS, Key.LT, Key.A, Key.E, Key.RP])
+
+        assert stroke.get_vowels() == [Key.A, Key.E]
+
+    def test_get_vowels_no_vowels(self):
+        stroke = Stroke([Key.LS, Key.LT, Key.STAR, Key.RP])
+
+        assert stroke.get_vowels() == []
+
+    #################################################################
+    # Test get_last_key()
+    #################################################################
+
+    def test_get_last_key_empty_stroke(self):
+        stroke = Stroke()
+
+        assert stroke.get_last_key() is None
+
+    def test_get_last_key_only_star(self):
+        stroke = Stroke([Key.STAR])
+
+        assert stroke.get_last_key() is None
+
+    def test_get_last_key_only_num(self):
+        stroke = Stroke([Key.NUM])
+
+        assert stroke.get_last_key() is None
+
+    def test_get_last_key_with_valid_last_key(self):
+        stroke = Stroke([Key.LH, Key.A, Key.RT])
+
+        assert stroke.get_last_key() == Key.RT
+
+    def test_get_last_key_star_does_not_count(self):
+        stroke = Stroke([Key.LH, Key.A, Key.STAR])
+
+        assert stroke.get_last_key() == Key.A
+
+    #################################################################
+    # Test get_keys()
+    #################################################################
+
+    def test_get_keys_empty_stroke(self):
+        stroke = Stroke()
+
+        assert stroke.get_keys() == []
+
+    def test_get_keys_no_star(self):
+        keys = [Key.LS, Key.LH, Key.E, Key.RL, Key.RD]
+        stroke = Stroke(keys)
+
+        assert stroke.get_keys() == keys
+
+    def test_get_keys_with_star(self):
+        keys = [Key.LS, Key.LH, Key.STAR, Key.E, Key.RL, Key.RD]
+        stroke = Stroke(keys)
+
+        assert stroke.get_keys() == keys
+
+    #################################################################
+    # Test is_empty()
+    #################################################################
+
+    def test_is_empty_true_when_empty(self):
+        stroke = Stroke()
+
+        assert stroke.is_empty()
+
+    def test_is_empty_false_when_not_empty(self):
+        stroke = Stroke([Key.LS, Key.LH, Key.E, Key.RL, Key.RD])
+
+        assert not stroke.is_empty()
+
+    def test_is_empty_false_when_only_star(self):
+        stroke = Stroke([Key.STAR])
+
+        assert not stroke.is_empty()
+
+    def test_is_empty_false_when_only_num(self):
+        stroke = Stroke([Key.NUM])
+
+        assert not stroke.is_empty()
+
+    #################################################################
+    # Test has_left_consonant()
+    #################################################################
+
+    def test_is_empty_false_when_empty(self):
+        stroke = Stroke()
+
+        assert not stroke.has_left_consonant()
+
+    def test_is_empty_false_when_no_left_consonants(self):
+        stroke = Stroke([Key.A, Key.RR, Key.RL, Key.RD])
+
+        assert not stroke.has_left_consonant()
+
+    def test_is_empty_true_when_one_left_consonant(self):
+        stroke = Stroke([Key.LR, Key.A, Key.RR, Key.RL, Key.RD])
+
+        assert stroke.has_left_consonant()
+
+    def test_is_empty_true_when_multiple_left_consonants(self):
+        stroke = Stroke([Key.LK, Key.LW, Key.LH, Key.A, Key.RR, Key.RL, Key.RD])
+
+        assert stroke.has_left_consonant()
+
+    #################################################################
+    # Test has_right_consonant()
+    #################################################################
+
+    def test_is_empty_false_when_empty(self):
+        stroke = Stroke()
+
+        assert not stroke.has_right_consonant()
+
+    def test_is_empty_false_when_no_right_consonants(self):
+        stroke = Stroke([Key.LW, Key.LH, Key.A])
+
+        assert not stroke.has_right_consonant()
+
+    def test_is_empty_true_when_one_right_consonant(self):
+        stroke = Stroke([Key.LW, Key.LH, Key.A, Key.RF])
+
+        assert stroke.has_right_consonant()
+
+    def test_is_empty_true_when_multiple_right_consonants(self):
+        stroke = Stroke([Key.LW, Key.A, Key.RR, Key.RL, Key.RD])
+
+        assert stroke.has_right_consonant()
+
+    #################################################################
+    # Test left_consonants_match()
+    #################################################################
+
+    def test_left_consonants_match_true_when_both_empty(self):
+        stroke1 = Stroke()
+        stroke2 = Stroke()
+
+        assert stroke1.left_consonants_match(stroke2)
+
+    def test_left_consonants_match_true_when_both_no_left_consonants(self):
+        stroke1 = Stroke([Key.A, Key.RF])
+        stroke2 = Stroke([Key.O, Key.STAR, Key.RL])
+
+        assert stroke1.left_consonants_match(stroke2)
+
+    def test_left_consonants_match_false_when_only_partial_match(self):
+        stroke1 = Stroke([Key.LW, Key.LH, Key.A, Key.RF])
+        stroke2 = Stroke([Key.LP, Key.LH, Key.A, Key.RF])
+
+        assert not stroke1.left_consonants_match(stroke2)
+
+    def test_left_consonants_match_false_when_subset_match(self):
+        stroke1 = Stroke([Key.LW, Key.LH, Key.A, Key.RF])
+        stroke2 = Stroke([Key.LW, Key.LH, Key.LR, Key.A, Key.RF])
+
+        assert not stroke1.left_consonants_match(stroke2)
+
+    def test_left_consonants_match_true_when_full_match(self):
+        stroke1 = Stroke([Key.LW, Key.LH, Key.A, Key.RR, Key.RD])
+        stroke2 = Stroke([Key.LW, Key.LH, Key.O, Key.RG])
+
+        assert stroke1.left_consonants_match(stroke2)
+
+    #################################################################
+    # Test vowels_match()
+    #################################################################
+
+    def test_vowels_match_true_when_both_empty(self):
+        stroke1 = Stroke()
+        stroke2 = Stroke()
+
+        assert stroke1.vowels_match(stroke2)
+
+    def test_vowels_match_true_when_both_no_vowels(self):
+        stroke1 = Stroke([Key.LW, Key.LH])
+        stroke2 = Stroke([Key.LS, Key.STAR, Key.RL])
+
+        assert stroke1.vowels_match(stroke2)
+
+    def test_vowels_match_false_when_only_partial_match(self):
+        stroke1 = Stroke([Key.LH, Key.A, Key.O, Key.RF, Key.RG])
+        stroke2 = Stroke([Key.LH, Key.A, Key.U, Key.RF, Key.RG])
+
+        assert not stroke1.vowels_match(stroke2)
+
+    def test_vowels_match_false_when_subset_match(self):
+        stroke1 = Stroke([Key.A, Key.O, Key.RF, Key.RP])
+        stroke2 = Stroke([Key.A, Key.O, Key.U, Key.RF, Key.RP])
+
+        assert not stroke1.vowels_match(stroke2)
+
+    def test_vowels_match_true_when_full_match(self):
+        stroke1 = Stroke([Key.LW, Key.LH, Key.A, Key.E, Key.RL, Key.RD])
+        stroke2 = Stroke([Key.LK, Key.A, Key.STAR, Key.E, Key.RD])
+
+        assert stroke1.vowels_match(stroke2)
+
+    #################################################################
+    # Test right_consonants_match()
+    #################################################################
+
+    def test_right_consonants_match_true_when_both_empty(self):
+        stroke1 = Stroke()
+        stroke2 = Stroke()
+
+        assert stroke1.right_consonants_match(stroke2)
+
+    def test_right_consonants_match_true_when_both_no_right_consonants(self):
+        stroke1 = Stroke([Key.LW, Key.A])
+        stroke2 = Stroke([Key.LS, Key.O, Key.STAR, Key.U])
+
+        assert stroke1.right_consonants_match(stroke2)
+
+    def test_right_consonants_match_false_when_only_partial_match(self):
+        stroke1 = Stroke([Key.LH, Key.A, Key.RF, Key.RG])
+        stroke2 = Stroke([Key.LH, Key.A, Key.RF, Key.RL])
+
+        assert not stroke1.right_consonants_match(stroke2)
+
+    def test_right_consonants_match_false_when_subset_match(self):
+        stroke1 = Stroke([Key.LW, Key.LH, Key.A, Key.RF, Key.RP])
+        stroke2 = Stroke([Key.LW, Key.LH, Key.A, Key.RF, Key.RP, Key.RL])
+
+        assert not stroke1.right_consonants_match(stroke2)
+
+    def test_right_consonants_match_true_when_full_match(self):
+        stroke1 = Stroke([Key.LW, Key.LH, Key.A, Key.RR, Key.RD])
+        stroke2 = Stroke([Key.LK, Key.LR, Key.O, Key.STAR, Key.RR, Key.RD])
+
+        assert stroke1.right_consonants_match(stroke2)
+
+
+#####################################################################
+# Test StrokeSequence class
+#####################################################################
+
+
+class TestStrokeSequence:
+    #################################################################
+    # Test __init__()
+    #################################################################
+
+    def test_init_empty(self):
+        sequence = StrokeSequence()
+
+        assert sequence.get_strokes() == []
+
+    def test_init_empty_list(self):
+        sequence = StrokeSequence([])
+
+        assert sequence.get_strokes() == []
+
+    def test_init_one_stroke(self):
+        strokes = [Stroke([Key.A, Key.RT])]
+        sequence = StrokeSequence(strokes)
+
+        assert sequence.get_strokes() == strokes
+
+    def test_init_multiple_strokes(self):
+        strokes = [Stroke([Key.A, Key.RT]), Stroke([Key.LW, Key.STAR])]
+        sequence = StrokeSequence(strokes)
+
+        assert sequence.get_strokes() == strokes
+
+    #################################################################
+    # Test __eq__()
+    #################################################################
+
+    def test_equality_true_when_empty(self):
+        sequence = StrokeSequence()
+
+        assert sequence.get_strokes() == []
+
+    def test_equality_true_when_same_strokes(self):
+        strokes = [Stroke([Key.A, Key.RT]), Stroke([Key.LW, Key.STAR])]
+        sequence1 = StrokeSequence(strokes)
+        sequence2 = StrokeSequence(strokes)
+
+        assert sequence1 == sequence2
+
+    def test_equality_true_when_stroke_copies(self):
+        strokes = [Stroke([Key.A, Key.RT]), Stroke([Key.LW, Key.STAR])]
+        sequence1 = StrokeSequence(strokes)
+        sequence2 = StrokeSequence(copy.deepcopy(strokes))
+
+        assert sequence1 == sequence2
+
+    def test_equality_false_when_different_strokes(self):
+        strokes1 = [Stroke([Key.A, Key.RT]), Stroke([Key.LW, Key.STAR])]
+        strokes2 = [Stroke([Key.A, Key.RT]), Stroke([Key.O, Key.RG, Key.RZ])]
+        sequence1 = StrokeSequence(strokes1)
+        sequence2 = StrokeSequence(strokes2)
+
+        assert sequence1 != sequence2
+
+    def test_equality_false_when_differs_by_star(self):
+        strokes1 = [Stroke([Key.A, Key.RT])]
+        strokes2 = [Stroke([Key.A, Key.STAR, Key.RT])]
+        sequence1 = StrokeSequence(strokes1)
+        sequence2 = StrokeSequence(strokes2)
+
+        assert sequence1 != sequence2
+
+    #################################################################
+    # Test __str__()
+    #################################################################
+
+    def test_str_empty(self):
+        sequence = StrokeSequence([Stroke()])
+
+        assert str(sequence) == ""
+
+    def test_init_one_stroke(self):
+        sequence = StrokeSequence([Stroke([Key.A, Key.RG, Key.RZ])])
+
+        assert str(sequence) == "AGZ"
+
+    def test_init_multiple_strokes(self):
+        sequence = StrokeSequence([Stroke([Key.A, Key.RT]), Stroke([Key.LW, Key.STAR])])
+
+        assert str(sequence) == "AT/W*"
+
+    def test_init_multiple_strokes_with_some_empty(self):
+        strokes = [
+            Stroke(),
+            Stroke([Key.LW, Key.U, Key.RG]),
+            Stroke([Key.STAR, Key.RB]),
+            Stroke(),
+            Stroke(),
+            Stroke([Key.LH, Key.RP, Key.RZ]),
+            Stroke(),
+        ]
+        sequence = StrokeSequence(strokes)
+
+        assert str(sequence) == "WUG/*B/H-PZ"

--- a/tests/generator/test_syllable.py
+++ b/tests/generator/test_syllable.py
@@ -1,0 +1,271 @@
+from syllable import Syllable, SyllableRegion, SyllableAtom
+
+
+#####################################################################
+# Test __init__()
+#####################################################################
+
+
+def test_init():
+    syllable = Syllable(["k", "l"], "æ", ["p", "s"])
+    assert len(syllable._atoms) == 5
+    assert syllable._atoms[0] == SyllableAtom("k", SyllableRegion.ONSET)
+    assert syllable._atoms[1] == SyllableAtom("l", SyllableRegion.ONSET)
+    assert syllable._atoms[2] == SyllableAtom("æ", SyllableRegion.NUCLEUS)
+    assert syllable._atoms[3] == SyllableAtom("p", SyllableRegion.CODA)
+    assert syllable._atoms[4] == SyllableAtom("s", SyllableRegion.CODA)
+
+
+def test_init_empty():
+    syllable = Syllable([], "", [])
+    assert len(syllable._atoms) == 0
+
+
+def test_init_no_onset():
+    syllable = Syllable([], "a", ["d"])
+    assert len(syllable._atoms) == 2
+    assert syllable._atoms[0] == SyllableAtom("a", SyllableRegion.NUCLEUS)
+    assert syllable._atoms[1] == SyllableAtom("d", SyllableRegion.CODA)
+
+
+def test_init_no_nucleus():
+    syllable = Syllable(["p"], "", ["s"])
+    assert len(syllable._atoms) == 2
+    assert syllable._atoms[0] == SyllableAtom("p", SyllableRegion.ONSET)
+    assert syllable._atoms[1] == SyllableAtom("s", SyllableRegion.CODA)
+
+
+def test_init_no_coda():
+    syllable = Syllable(["b"], "o", [])
+    assert len(syllable._atoms) == 2
+    assert syllable._atoms[0] == SyllableAtom("b", SyllableRegion.ONSET)
+    assert syllable._atoms[1] == SyllableAtom("o", SyllableRegion.NUCLEUS)
+
+
+def test_init_one_one_phoneme_per_region():
+    syllable = Syllable(["k"], "æ", ["p"])
+    assert len(syllable._atoms) == 3
+    assert syllable._atoms[0] == SyllableAtom("k", SyllableRegion.ONSET)
+    assert syllable._atoms[1] == SyllableAtom("æ", SyllableRegion.NUCLEUS)
+    assert syllable._atoms[2] == SyllableAtom("p", SyllableRegion.CODA)
+
+
+def test_init_multiple_onsets():
+    syllable = Syllable(["p", "r", "t"], "æ", ["s"])
+    assert len(syllable._atoms) == 5
+    assert syllable._atoms[0] == SyllableAtom("p", SyllableRegion.ONSET)
+    assert syllable._atoms[1] == SyllableAtom("r", SyllableRegion.ONSET)
+    assert syllable._atoms[2] == SyllableAtom("t", SyllableRegion.ONSET)
+    assert syllable._atoms[3] == SyllableAtom("æ", SyllableRegion.NUCLEUS)
+    assert syllable._atoms[4] == SyllableAtom("s", SyllableRegion.CODA)
+
+
+def test_init_multiple_codas():
+    syllable = Syllable(["k"], "æ", ["p", "s", "t"])
+    assert len(syllable._atoms) == 5
+    assert syllable._atoms[0] == SyllableAtom("k", SyllableRegion.ONSET)
+    assert syllable._atoms[1] == SyllableAtom("æ", SyllableRegion.NUCLEUS)
+    assert syllable._atoms[2] == SyllableAtom("p", SyllableRegion.CODA)
+    assert syllable._atoms[3] == SyllableAtom("s", SyllableRegion.CODA)
+    assert syllable._atoms[4] == SyllableAtom("t", SyllableRegion.CODA)
+
+
+def test_init_long_nucleus():
+    syllable = Syllable(["k"], "aeiou", ["p"])
+    assert len(syllable._atoms) == 3
+    assert syllable._atoms[0] == SyllableAtom("k", SyllableRegion.ONSET)
+    assert syllable._atoms[1] == SyllableAtom("aeiou", SyllableRegion.NUCLEUS)
+    assert syllable._atoms[2] == SyllableAtom("p", SyllableRegion.CODA)
+
+
+#####################################################################
+# Test __str__()
+#####################################################################
+
+
+def test_str_empty_syllable():
+    syllable = Syllable([], "", [])
+    assert str(syllable) == ""
+
+
+def test_str_only_onset():
+    syllable = Syllable(["b"], "", [])
+    assert str(syllable) == "b"
+
+
+def test_str_only_nucleus():
+    syllable = Syllable([], "a", [])
+    assert str(syllable) == "a"
+
+
+def test_str_only_coda():
+    syllable = Syllable([], "", ["t"])
+    assert str(syllable) == "t"
+
+
+def test_str_no_onset():
+    syllable = Syllable([], "a", ["s"])
+    assert str(syllable) == "as"
+
+
+def test_str_no_nucleus():
+    syllable = Syllable(["f"], "", ["t"])
+    assert str(syllable) == "ft"
+
+
+def test_str_no_coda():
+    syllable = Syllable(["k"], "a", [])
+    assert str(syllable) == "ka"
+
+
+def test_str_onset_nucleus_coda():
+    syllable = Syllable(["p", "l"], "a", ["n", "t"])
+    assert str(syllable) == "plant"
+
+
+#####################################################################
+# Test is_last_phoneme_s()
+#####################################################################
+
+
+def test_is_last_phoneme_s_true():
+    syllable = Syllable(onset=["t"], nucleus="ɪ", coda=["s"])
+    assert syllable.is_last_phoneme_s() == True
+
+
+def test_is_last_phoneme_s_false():
+    syllable = Syllable(onset=["p"], nucleus="aʊ", coda=["t"])
+    assert syllable.is_last_phoneme_s() == False
+
+
+def test_is_last_phoneme_s_empty():
+    syllable = Syllable(onset=[], nucleus="", coda=[])
+    assert syllable.is_last_phoneme_s() == False
+
+
+def test_is_last_phoneme_s_multiple_coda_sounds_true():
+    syllable = Syllable(onset=["m"], nucleus="ɑ", coda=["t", "s"])
+    assert syllable.is_last_phoneme_s() == True
+
+
+def test_is_last_phoneme_s_multiple_coda_sounds_false():
+    syllable = Syllable(onset=["b"], nucleus="ɔ", coda=["ɹ", "d"])
+    assert syllable.is_last_phoneme_s() == False
+
+
+#####################################################################
+# Test map_atoms()
+#####################################################################
+
+
+def test_map_atoms_empty():
+    syllable = Syllable([], "", [])
+    atom_tuples_to_objs = {
+        (
+            SyllableAtom("t", SyllableRegion.ONSET),
+            SyllableAtom("i", SyllableRegion.NUCLEUS),
+            SyllableAtom("n", SyllableRegion.CODA),
+        ): "Object 1"
+    }
+    objs = syllable.map_atoms(atom_tuples_to_objs)
+    assert objs == []
+
+
+def test_map_atoms_one_big_cluster():
+    syllable = Syllable(["t"], "i", ["n"])
+    atom_tuples_to_objs = {
+        (
+            SyllableAtom("t", SyllableRegion.ONSET),
+            SyllableAtom("i", SyllableRegion.NUCLEUS),
+            SyllableAtom("n", SyllableRegion.CODA),
+        ): "Object"
+    }
+    objs = syllable.map_atoms(atom_tuples_to_objs)
+    assert objs == ["Object"]
+
+
+def test_map_atoms_with_single_phonemes():
+    syllable = Syllable(["k"], "æ", ["s"])
+    atom_tuples_to_obj = {
+        (SyllableAtom("k", SyllableRegion.ONSET),): "k",
+        (SyllableAtom("æ", SyllableRegion.NUCLEUS),): "a",
+        (SyllableAtom("s", SyllableRegion.CODA),): "s",
+    }
+    objs = syllable.map_atoms(atom_tuples_to_obj)
+    assert objs == ["k", "a", "s"]
+
+
+def test_map_atoms_same_prefix():
+    syllable = Syllable(["t", "s"], "i", ["n"])
+    atom_tuples_to_objs = {
+        (
+            SyllableAtom("t", SyllableRegion.ONSET),
+            SyllableAtom("i", SyllableRegion.NUCLEUS),
+            SyllableAtom("n", SyllableRegion.CODA),
+        ): "Object 1",
+        (
+            SyllableAtom("t", SyllableRegion.ONSET),
+            SyllableAtom("s", SyllableRegion.ONSET),
+            SyllableAtom("i", SyllableRegion.NUCLEUS),
+            SyllableAtom("n", SyllableRegion.CODA),
+        ): "Object 2",
+    }
+    objs = syllable.map_atoms(atom_tuples_to_objs)
+    assert objs == ["Object 2"]
+
+
+def test_map_atoms_with_missing_key():
+    syllable = Syllable(["t", "s"], "i", ["n"])
+    atom_tuples_to_objs = {
+        (
+            SyllableAtom("t", SyllableRegion.ONSET),
+            SyllableAtom("i", SyllableRegion.NUCLEUS),
+            SyllableAtom("n", SyllableRegion.CODA),
+        ): "Object 1"
+    }
+    objs = syllable.map_atoms(atom_tuples_to_objs)
+    assert objs == None
+
+
+def test_map_atoms_with_clusters():
+    syllable = Syllable(["k", "l"], "æ", ["p", "s"])
+    atom_tuples_to_obj = {
+        (SyllableAtom("k", SyllableRegion.ONSET), SyllableAtom("l", SyllableRegion.ONSET)): "kwel",
+        (SyllableAtom("æ", SyllableRegion.NUCLEUS),): "a",
+        (SyllableAtom("s", SyllableRegion.CODA),): "zzz",
+        (SyllableAtom("p", SyllableRegion.CODA),): "y",
+    }
+    objs = syllable.map_atoms(atom_tuples_to_obj)
+    assert objs == ["kwel", "a", "y", "zzz"]
+
+
+def test_map_atoms_clusters_take_precedence():
+    syllable = Syllable(["k", "l"], "æ", ["p", "s"])
+    atom_tuples_to_obj = {
+        (SyllableAtom("k", SyllableRegion.NUCLEUS),): "b",
+        (
+            SyllableAtom("k", SyllableRegion.ONSET),
+            SyllableAtom("l", SyllableRegion.ONSET),
+        ): "cluster1",
+        (SyllableAtom("l", SyllableRegion.NUCLEUS),): "m",
+        (SyllableAtom("æ", SyllableRegion.NUCLEUS),): "a",
+        (SyllableAtom("s", SyllableRegion.CODA),): "zzz",
+        (SyllableAtom("p", SyllableRegion.CODA),): "y",
+        (
+            SyllableAtom("p", SyllableRegion.CODA),
+            SyllableAtom("s", SyllableRegion.CODA),
+        ): "cluster2",
+    }
+    objs = syllable.map_atoms(atom_tuples_to_obj)
+    assert objs == ["cluster1", "a", "cluster2"]
+
+
+def test_map_atoms_with_overlap():
+    syllable = Syllable(["t", "ʃ"], "ɛ", ["p"])
+    atom_tuples_to_obj = {
+        (SyllableAtom("t", SyllableRegion.ONSET), SyllableAtom("ʃ", SyllableRegion.ONSET)): "tʃ",
+        (SyllableAtom("ʃ", SyllableRegion.ONSET), SyllableAtom("ɛ", SyllableRegion.NUCLEUS)): "ʃɛ",
+        (SyllableAtom("ɛ", SyllableRegion.NUCLEUS), SyllableAtom("p", SyllableRegion.CODA)): "ɛp",
+    }
+    objs = syllable.map_atoms(atom_tuples_to_obj)
+    assert objs == ["tʃ", "ɛp"]


### PR DESCRIPTION
This adds all the unit tests for `syllable.py` and `steno.py`, and sets up a GitHub workflow to run these tests. More tests are needed to fully test the `generator` module, but this gets the ball rolling in terms of testing.

To run the tests manually:
```
cd generator
python -m pytest ../tests/generator
```

At some point the project code should be reorganized and a `setup.py` or `pyproject.toml` should be created. After that, some of the `import` statements should change since then Python will know about the project structure, and the workflow for running tests should be updated so that it runs all tests within the project. Without making a `pyproject.toml` and restructuring the code the imports are a bit tricky to get to work for both running a script and running test scripts that import those scripts; so the current workflow changes into the `generator` directory and only runs the tests in `tests/generator`.